### PR TITLE
Fix notion_append_content tool schema missing page_id

### DIFF
--- a/src/models/notion.py
+++ b/src/models/notion.py
@@ -94,6 +94,7 @@ class UpdatePageRequest(BaseModel):
 class AppendContentRequest(BaseModel):
     """Request model for appending content to a page."""
 
+    page_id: str = Field(..., description="Notion page ID")
     content: str = Field(..., description="Content to append")
 
 


### PR DESCRIPTION
## Summary

`notion_append_content` was always failing with:

```
ERROR - Tool execution failed: NotionService.append_content() missing 1 required positional argument: 'page_id'
```

The root cause: `AppendContentRequest` (the Pydantic model that generates the tool's JSON schema) only exposed `content` — no `page_id` field. Since the executor calls `service.append_content(**arguments)`, and `NotionService.append_content(self, page_id: str, content: str)` requires `page_id`, no agent could ever supply it — the schema didn't allow it.

## Change

`src/models/notion.py` — added one field to `AppendContentRequest`:

```python
page_id: str = Field(..., description="Notion page ID")
```

`create_tool_schema` derives the JSON schema directly from this model, so the tool's exposed parameters now include `page_id` as required, matching what the backend expects.
