### PR TITLE
Add reactive 401 retry for api_key_with_jwt authentication

### DIFF
--- a/docs/plugin-schema.md
+++ b/docs/plugin-schema.md
@@ -80,7 +80,7 @@ Plugins are JSON files that define lightweight REST API integrations. Each plugi
 - **JWT login only** (omit `api_key_header`): POSTs `{"username": ..., "password": ...}` to `{token_endpoint}`, then attaches `Authorization: {token_prefix} {jwt}` to every API call. User provides **Username** and **Password**.
 - **JWT login + static API key** (set `api_key_header`): same as above, but also sends `{api_key_header}: {api_key}` on both the login request and every API call. User provides **API Key**, **Username**, and **Password**.
 
-In both cases the JWT is cached (TTL from the `exp` claim; defaults to 55 minutes) and refreshed automatically before expiry.
+In both cases the JWT is cached (TTL from the `exp` claim; defaults to 55 minutes) and refreshed automatically before expiry. If the server rejects a request with a 401 (e.g. the token was revoked early or there is clock skew), the cache is cleared and the request is retried once with a freshly fetched token.
 
 ---
 
@@ -276,7 +276,7 @@ Some APIs additionally require a permanent API key header alongside the JWT. Add
 }
 ```
 
-The user provides **API Key**, **Username**, and **Password**. The API key is sent as `X-apikey` on both the login request and every subsequent API call. The JWT is cached and refreshed automatically before expiry.
+The user provides **API Key**, **Username**, and **Password**. The API key is sent as `X-apikey` on both the login request and every subsequent API call. The JWT is cached, refreshed automatically before expiry, and re-fetched on 401 responses.
 
 ---
 

--- a/src/services/plugin_service.py
+++ b/src/services/plugin_service.py
@@ -310,6 +310,25 @@ class PluginService(BaseService):
                 json=json_body if not use_ado_patch_content_type else None,
             )
 
+            if response.status_code == 401 and defn.auth.type == "api_key_with_jwt":
+                # Token was rejected — evict the stale cache entry and retry once
+                self._jwt_cache.pop(plugin_id, None)
+                retry_headers: Dict[str, str] = {"Content-Type": "application/json"}
+                retry_headers.update(
+                    await self._resolve_auth_headers(plugin_id, defn, creds, defn.base_url)
+                )
+                if use_ado_patch_content_type:
+                    retry_headers["Content-Type"] = "application/json-patch+json"
+                retry_headers.update(header_params)
+                response = await client.request(
+                    method=endpoint.method,
+                    url=url,
+                    headers=retry_headers,
+                    params=query_params if query_params else None,
+                    content=json.dumps(json_body) if use_ado_patch_content_type else None,
+                    json=json_body if not use_ado_patch_content_type else None,
+                )
+
         response.raise_for_status()
 
         # Return None body as empty dict

--- a/tests/test_plugin_dual_auth.py
+++ b/tests/test_plugin_dual_auth.py
@@ -385,7 +385,8 @@ class TestExecuteEndpoint401Retry:
         jwt_v2 = _make_jwt(3600)
 
         self.svc._jwt_cache["my_service"] = (
-            jwt_v1, datetime.now(timezone.utc) + timedelta(hours=1)
+            jwt_v1,
+            datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
         resp_401 = MagicMock()
@@ -421,7 +422,8 @@ class TestExecuteEndpoint401Retry:
         import httpx as real_httpx
 
         self.svc._jwt_cache["my_service"] = (
-            _make_jwt(3600), datetime.now(timezone.utc) + timedelta(hours=1)
+            _make_jwt(3600),
+            datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
         resp_401 = MagicMock()

--- a/tests/test_plugin_dual_auth.py
+++ b/tests/test_plugin_dual_auth.py
@@ -354,3 +354,137 @@ class TestSaveCredentials:
         req = PluginCredentialsRequest(api_key="NEWKEY", username="alice", password="newpass")
         self.svc.save_credentials("my_service", req)
         assert "my_service" not in self.svc._jwt_cache
+
+
+# ---------------------------------------------------------------------------
+# _execute_endpoint — reactive 401 retry for api_key_with_jwt
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteEndpoint401Retry:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+        self.defn = _dual_auth_definition()
+        self.svc._definitions["my_service"] = self.defn
+        self.svc.credentials_repo.get.side_effect = lambda key: (
+            {"credential_data": {"api_key": "K", "username": "u", "password": "p"}}
+            if key == "plugin_my_service"
+            else None
+        )
+
+    def _make_api_client_mock(self, *responses):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.request = AsyncMock(side_effect=list(responses))
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_retries_on_401_and_succeeds(self):
+        jwt_v1 = _make_jwt(3600)
+        jwt_v2 = _make_jwt(3600)
+
+        self.svc._jwt_cache["my_service"] = (
+            jwt_v1, datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        resp_401.content = b""
+
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.content = b'{"items": []}'
+        resp_200.json.return_value = {"items": []}
+        resp_200.raise_for_status = MagicMock()
+
+        mock_client = self._make_api_client_mock(resp_401, resp_200)
+        headers_v1 = {"Authorization": f"Access_Token {jwt_v1}", "X-apikey": "K"}
+        headers_v2 = {"Authorization": f"Access_Token {jwt_v2}", "X-apikey": "K"}
+
+        with (
+            patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client),
+            patch.object(
+                self.svc,
+                "_resolve_auth_headers",
+                AsyncMock(side_effect=[headers_v1, headers_v2]),
+            ),
+        ):
+            result = await self.svc._execute_endpoint("my_service", "list_items", {})
+
+        assert result == {"items": []}
+        assert mock_client.request.call_count == 2
+        assert "my_service" not in self.svc._jwt_cache
+
+    @pytest.mark.asyncio
+    async def test_raises_when_retry_also_returns_401(self):
+        import httpx as real_httpx
+
+        self.svc._jwt_cache["my_service"] = (
+            _make_jwt(3600), datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        resp_401.content = b""
+        resp_401.raise_for_status = MagicMock(
+            side_effect=real_httpx.HTTPStatusError(
+                "401", request=MagicMock(), response=MagicMock(status_code=401)
+            )
+        )
+
+        mock_client = self._make_api_client_mock(resp_401, resp_401)
+
+        with (
+            patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client),
+            patch.object(
+                self.svc,
+                "_resolve_auth_headers",
+                AsyncMock(return_value={"Authorization": "Access_Token tok"}),
+            ),
+        ):
+            with pytest.raises(real_httpx.HTTPStatusError):
+                await self.svc._execute_endpoint("my_service", "list_items", {})
+
+        assert mock_client.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_jwt_auth_does_not_retry_on_401(self):
+        import httpx as real_httpx
+
+        bearer_defn = PluginDefinition.model_validate(
+            {
+                "id": "bearer_svc",
+                "display_name": "Bearer",
+                "description": "Bearer auth plugin.",
+                "base_url": "https://api.example.com",
+                "auth": {"type": "bearer"},
+                "endpoints": [
+                    {
+                        "name": "get_data",
+                        "display_name": "Get",
+                        "description": ".",
+                        "method": "GET",
+                        "path": "/data",
+                    }
+                ],
+            }
+        )
+        self.svc._definitions["bearer_svc"] = bearer_defn
+
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        resp_401.content = b""
+        resp_401.raise_for_status = MagicMock(
+            side_effect=real_httpx.HTTPStatusError(
+                "401", request=MagicMock(), response=MagicMock(status_code=401)
+            )
+        )
+
+        mock_client = self._make_api_client_mock(resp_401)
+
+        with patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(real_httpx.HTTPStatusError):
+                await self.svc._execute_endpoint("bearer_svc", "get_data", {})
+
+        assert mock_client.request.call_count == 1


### PR DESCRIPTION
## Summary
Implements automatic retry logic for API endpoints using `api_key_with_jwt` authentication when receiving a 401 (Unauthorized) response. This handles the case where a cached JWT token becomes stale or invalid during request execution.

## Key Changes
- **Reactive 401 retry mechanism**: When an endpoint with `api_key_with_jwt` auth receives a 401 response, the service now:
  - Evicts the stale JWT from the cache
  - Resolves fresh authentication headers (which triggers a new JWT generation)
  - Retries the request once with the new token
  
- **Auth-type specific behavior**: The retry logic only applies to `api_key_with_jwt` authentication. Other auth types (e.g., bearer) will fail immediately on 401 without retry.

- **Comprehensive test coverage**: Added three test cases covering:
  - Successful retry scenario (401 followed by 200)
  - Failure when retry also returns 401
  - Verification that non-JWT auth types don't retry on 401

## Implementation Details
- The retry logic is implemented in `_execute_endpoint()` after the initial request
- Cache eviction (`_jwt_cache.pop()`) ensures a fresh token is generated on retry
- The retry request uses the same parameters and body as the original request
- If the retry also fails with 401, the error is propagated to the caller
