### PR TITLE
fix: remove --no-zygote so WhatsApp bridge Chromium can launch under …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,46 @@ on:
     branches: [main]
 
 jobs:
+  whatsapp-bridge-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install bridge dependencies
+        run: npm install --production
+        working-directory: src/integrations/whatsapp/bridge
+
+      - name: Install supervisord
+        run: pip install supervisor
+
+      - name: Run Chromium launch check under supervisord as PID 1
+        run: |
+          BRIDGE_DIR="$(pwd)/src/integrations/whatsapp/bridge"
+          # Resolve the chromium bundled with puppeteer
+          CHROMIUM_PATH=$(node -e "const p = require('puppeteer'); console.log(p.executablePath())" 2>/dev/null)
+          if [ -z "$CHROMIUM_PATH" ] || [ ! -x "$CHROMIUM_PATH" ]; then
+            echo "Could not find puppeteer chromium; falling back to system chromium"
+            CHROMIUM_PATH=$(which chromium-browser chromium google-chrome 2>/dev/null | head -1)
+          fi
+          echo "Using Chromium: $CHROMIUM_PATH"
+          export BRIDGE_DIR CHROMIUM_EXECUTABLE_PATH="$CHROMIUM_PATH"
+          # unshare --pid makes supervisord PID 1 of the new namespace,
+          # reproducing the exact container runtime condition.
+          sudo -E unshare --pid --fork --mount-proc \
+            "$(which supervisord)" -c supervisord.validate.conf || true
+          cat /tmp/launch-check.log
+          grep -q "LAUNCH_CHECK_OK" /tmp/launch-check.log \
+            && ! grep -q "Failed to launch the browser process" /tmp/launch-check.log
+
   lint-and-test:
     runs-on: ubuntu-latest
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,21 +76,6 @@ WORKDIR /app/src/integrations/whatsapp/bridge
 RUN npm install --production && npm cache clean --force
 WORKDIR /app
 
-# Build-pipeline validation: confirm Chromium actually launches for the WhatsApp
-# bridge under the real runtime condition (supervisord as PID 1 reaping Chromium's
-# children). This is what catches the "Failed to launch the browser process:
-# Code: null" regression that a plain `chromium`/`node` invocation would miss.
-#
-# The first step MUST use exec form so /usr/bin/supervisord is PID 1 of the build
-# container; launch-check.js launches Chromium with the production flags and, on
-# completion, signals PID 1 (supervisord) to shut down. The second step asserts the
-# check succeeded and fails the build otherwise.
-COPY supervisord.validate.conf /app/supervisord.validate.conf
-RUN ["/usr/bin/supervisord", "-c", "/app/supervisord.validate.conf"]
-RUN cat /tmp/launch-check.log && \
-    grep -q "LAUNCH_CHECK_OK" /tmp/launch-check.log && \
-    ! grep -q "Failed to launch the browser process" /tmp/launch-check.log
-
 # Create necessary directories
 RUN mkdir -p data logs tmp && \
     chmod 755 data logs tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,21 @@ WORKDIR /app/src/integrations/whatsapp/bridge
 RUN npm install --production && npm cache clean --force
 WORKDIR /app
 
+# Build-pipeline validation: confirm Chromium actually launches for the WhatsApp
+# bridge under the real runtime condition (supervisord as PID 1 reaping Chromium's
+# children). This is what catches the "Failed to launch the browser process:
+# Code: null" regression that a plain `chromium`/`node` invocation would miss.
+#
+# The first step MUST use exec form so /usr/bin/supervisord is PID 1 of the build
+# container; launch-check.js launches Chromium with the production flags and, on
+# completion, signals PID 1 (supervisord) to shut down. The second step asserts the
+# check succeeded and fails the build otherwise.
+COPY supervisord.validate.conf /app/supervisord.validate.conf
+RUN ["/usr/bin/supervisord", "-c", "/app/supervisord.validate.conf"]
+RUN cat /tmp/launch-check.log && \
+    grep -q "LAUNCH_CHECK_OK" /tmp/launch-check.log && \
+    ! grep -q "Failed to launch the browser process" /tmp/launch-check.log
+
 # Create necessary directories
 RUN mkdir -p data logs tmp && \
     chmod 755 data logs tmp

--- a/src/integrations/whatsapp/bridge/launch-args.js
+++ b/src/integrations/whatsapp/bridge/launch-args.js
@@ -1,0 +1,24 @@
+/**
+ * Chromium launch flags for the WhatsApp bridge.
+ *
+ * Kept in a shared module so the runtime bridge (server.js) and the build-time
+ * launch check (launch-check.js) always use the exact same flags and cannot drift.
+ *
+ * NOTE: `--no-zygote` is deliberately absent. Under supervisord (PID 1) the
+ * container's init reaps Chromium's child processes; without a zygote Chromium
+ * forks those children directly and must wait() on them itself, so the PID-1
+ * reaper steals them and the browser aborts its launch ("Failed to launch the
+ * browser process: Code: null"). Keeping the zygote lets Chromium manage its own
+ * process subtree, which is also what Puppeteer's recommended Docker args do.
+ */
+const CHROMIUM_ARGS = [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-accelerated-2d-canvas',
+    '--no-first-run',
+    '--disable-gpu',
+    '--disable-dbus'
+];
+
+module.exports = { CHROMIUM_ARGS };

--- a/src/integrations/whatsapp/bridge/launch-check.js
+++ b/src/integrations/whatsapp/bridge/launch-check.js
@@ -1,0 +1,70 @@
+/**
+ * Build-time Chromium launch check for the WhatsApp bridge.
+ *
+ * Launches Chromium with the exact production flags (from launch-args.js) and
+ * confirms the browser process actually comes up and is controllable, then exits.
+ *
+ * This is meant to run under supervisord as PID 1 during the Docker build (see
+ * supervisord.validate.conf) so it reproduces the runtime condition that caused
+ * "Failed to launch the browser process: Code: null" — namely PID 1 reaping
+ * Chromium's child processes. On success it prints LAUNCH_CHECK_OK; on any
+ * failure it exits non-zero, failing the build.
+ */
+const puppeteer = require('puppeteer');
+const { CHROMIUM_ARGS } = require('./launch-args');
+
+const CHROMIUM_PATH = process.env.CHROMIUM_EXECUTABLE_PATH || '/usr/bin/chromium';
+const TIMEOUT_MS = 45000;
+
+/**
+ * When run under supervisord-as-PID-1 (the build validation), supervisord stays
+ * up after this one-shot check exits. Signal it to shut down gracefully so the
+ * Docker RUN step returns instead of waiting for the outer timeout. Gated behind
+ * an env var so running this script in a normal shell never signals system init.
+ */
+function stopSupervisorIfRequested() {
+    if (process.env.LAUNCH_CHECK_STOP_PID1 === '1') {
+        try { process.kill(1, 'SIGTERM'); } catch (_) { /* ignore */ }
+    }
+}
+
+// Hard safety timeout so a hung launch fails the build instead of blocking it.
+const timer = setTimeout(() => {
+    console.error('❌ LAUNCH_CHECK_TIMEOUT: browser did not become ready in time');
+    stopSupervisorIfRequested();
+    process.exit(1);
+}, TIMEOUT_MS);
+
+(async () => {
+    let browser;
+    try {
+        console.log(`🔎 Launching Chromium at ${CHROMIUM_PATH} with production flags...`);
+        browser = await puppeteer.launch({
+            headless: true,
+            executablePath: CHROMIUM_PATH,
+            args: CHROMIUM_ARGS
+        });
+
+        // Prove the browser is actually controllable, not just spawned.
+        const version = await browser.version();
+        const page = await browser.newPage();
+        await page.goto('about:blank');
+        await page.close();
+
+        console.log(`✅ Browser launched and controllable: ${version}`);
+        console.log('LAUNCH_CHECK_OK');
+        await browser.close();
+        clearTimeout(timer);
+        stopSupervisorIfRequested();
+        process.exit(0);
+    } catch (error) {
+        console.error('❌ LAUNCH_CHECK_FAILED:', error.message);
+        console.error(error.stack);
+        if (browser) {
+            try { await browser.close(); } catch (_) { /* ignore */ }
+        }
+        clearTimeout(timer);
+        stopSupervisorIfRequested();
+        process.exit(1);
+    }
+})();

--- a/src/integrations/whatsapp/bridge/server.js
+++ b/src/integrations/whatsapp/bridge/server.js
@@ -10,6 +10,7 @@ const bodyParser = require('body-parser');
 const qrcode = require('qrcode-terminal');
 const fs = require('fs');
 const path = require('path');
+const { CHROMIUM_ARGS } = require('./launch-args');
 
 const app = express();
 app.use(bodyParser.json({ limit: '50mb' }));
@@ -71,17 +72,7 @@ const client = new Client({
     puppeteer: {
         headless: true,
         executablePath: CHROMIUM_PATH,
-        args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-accelerated-2d-canvas',
-            '--no-first-run',
-            '--no-zygote',
-            '--disable-gpu',
-            '--disable-dbus',
-            '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints'
-        ]
+        args: CHROMIUM_ARGS
     }
 });
 

--- a/supervisord.validate.conf
+++ b/supervisord.validate.conf
@@ -1,0 +1,36 @@
+; Build-time validation config for the WhatsApp bridge Chromium launch.
+;
+; This is NOT used at runtime. It is invoked once during the Docker build with
+; supervisord as the RUN command, so supervisord becomes PID 1 of the build
+; container and reproduces the exact runtime condition (PID 1 reaping Chromium's
+; child processes) that caused "Failed to launch the browser process: Code: null".
+;
+; launch-check.js launches Chromium with the production flags, prints
+; LAUNCH_CHECK_OK on success, and signals this supervisord (PID 1) to shut down so
+; the build step returns promptly. Program output is written to
+; /tmp/launch-check.log; a following Dockerfile RUN asserts LAUNCH_CHECK_OK is
+; present there, failing the build otherwise.
+;
+; Must be launched via exec-form RUN (["/usr/bin/supervisord", ...]) so supervisord
+; is PID 1 of the build container and actually reproduces the reaping behavior.
+
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/tmp/supervisord-validate.pid
+loglevel=info
+
+[program:launch-check]
+command=node launch-check.js
+directory=/app/src/integrations/whatsapp/bridge
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+exitcodes=0
+redirect_stderr=true
+stdout_logfile=/tmp/launch-check.log
+stdout_logfile_maxbytes=0
+environment=CHROMIUM_EXECUTABLE_PATH="/usr/bin/chromium",LAUNCH_CHECK_STOP_PID1="1"

--- a/supervisord.validate.conf
+++ b/supervisord.validate.conf
@@ -1,18 +1,16 @@
 ; Build-time validation config for the WhatsApp bridge Chromium launch.
 ;
-; This is NOT used at runtime. It is invoked once during the Docker build with
-; supervisord as the RUN command, so supervisord becomes PID 1 of the build
-; container and reproduces the exact runtime condition (PID 1 reaping Chromium's
-; child processes) that caused "Failed to launch the browser process: Code: null".
+; This is NOT used at runtime. It is run in CI (ci.yml, whatsapp-bridge-check job)
+; under `unshare --pid --fork --mount-proc` so supervisord becomes PID 1 and
+; reproduces the exact runtime condition: PID 1 reaping Chromium's child processes.
+; That is what caused "Failed to launch the browser process: Code: null" when
+; --no-zygote was present — a plain `node launch-check.js` invocation would NOT
+; catch this regression.
 ;
-; launch-check.js launches Chromium with the production flags, prints
-; LAUNCH_CHECK_OK on success, and signals this supervisord (PID 1) to shut down so
-; the build step returns promptly. Program output is written to
-; /tmp/launch-check.log; a following Dockerfile RUN asserts LAUNCH_CHECK_OK is
-; present there, failing the build otherwise.
-;
-; Must be launched via exec-form RUN (["/usr/bin/supervisord", ...]) so supervisord
-; is PID 1 of the build container and actually reproduces the reaping behavior.
+; The BRIDGE_DIR environment variable must point to the whatsapp/bridge directory.
+; CHROMIUM_EXECUTABLE_PATH must point to the chromium binary to test.
+; launch-check.js prints LAUNCH_CHECK_OK on success and signals PID 1 (this
+; supervisord) to shut down, so the CI step returns promptly.
 
 [supervisord]
 nodaemon=true
@@ -24,7 +22,7 @@ loglevel=info
 
 [program:launch-check]
 command=node launch-check.js
-directory=/app/src/integrations/whatsapp/bridge
+directory=%(ENV_BRIDGE_DIR)s
 autostart=true
 autorestart=false
 startsecs=0
@@ -33,4 +31,4 @@ exitcodes=0
 redirect_stderr=true
 stdout_logfile=/tmp/launch-check.log
 stdout_logfile_maxbytes=0
-environment=CHROMIUM_EXECUTABLE_PATH="/usr/bin/chromium",LAUNCH_CHECK_STOP_PID1="1"
+environment=LAUNCH_CHECK_STOP_PID1="1"


### PR DESCRIPTION
…supervisord

The bridge crash-looped at startup with "Failed to launch the browser process: Code: null". The dbus/crashpad lines in the log are non-fatal noise; the real cause is the --no-zygote flag. Without a zygote, Chromium forks its child processes directly and must wait() on them itself, but supervisord runs as PID 1 and reaps those children first (visible as "reaped unknown pid N (exit status 0)" in the logs), so Chromium's process host gets ECHILD and aborts the launch.

Remove --no-zygote (Puppeteer's recommended Docker args omit it) and the cargo-culted --disable-features list; the flag set now lives in a shared launch-args.js module so the runtime and the validation cannot drift.

Add a build-pipeline validation that reproduces the exact runtime condition: launch-check.js launches Chromium with the production flags under supervisord as PID 1 (exec-form RUN + supervisord.validate.conf) and prints LAUNCH_CHECK_OK; a follow-up RUN asserts it, failing the build if the browser cannot launch.