### PR TITLE
fix(whatsapp): harden bridge against Chromium launch failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-assistant"
-version = "1.2.4"
+version = "1.2.5"
 description = "AI-powered personal assistant for task automation and integration"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/integrations/whatsapp/bridge/package-lock.json
+++ b/src/integrations/whatsapp/bridge/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^4.18.2",
         "node-fetch": "^2.7.0",
         "qrcode-terminal": "^0.12.0",
-        "whatsapp-web.js": "^1.23.0"
+        "whatsapp-web.js": "1.34.7"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/src/integrations/whatsapp/bridge/package.json
+++ b/src/integrations/whatsapp/bridge/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "whatsapp-web.js": "^1.23.0",
+    "whatsapp-web.js": "1.34.7",
     "express": "^4.18.2",
     "body-parser": "^1.20.2",
     "qrcode-terminal": "^0.12.0",

--- a/src/integrations/whatsapp/bridge/server.js
+++ b/src/integrations/whatsapp/bridge/server.js
@@ -18,10 +18,7 @@ app.use(bodyParser.json({ limit: '50mb' }));
 const PORT = process.env.WHATSAPP_BRIDGE_PORT || 3001;
 const SESSION_PATH = process.env.WHATSAPP_SESSION_DIR || './whatsapp_session';
 const WEBHOOK_URL = process.env.WHATSAPP_WEBHOOK_URL || 'http://localhost:8080/api/whatsapp/webhook/incoming';
-// Default matches the Debian `chromium` apt package installed in the Dockerfile
-// (/usr/bin/chromium, not chromium-browser) and launch-check.js. supervisord
-// sets CHROMIUM_EXECUTABLE_PATH explicitly; this fallback keeps the bridge
-// launchable if it's ever run without that env (e.g. locally or in CI).
+// Default to /usr/bin/chromium (the Debian apt package path), matching the Dockerfile.
 const CHROMIUM_PATH = process.env.CHROMIUM_EXECUTABLE_PATH || '/usr/bin/chromium';
 
 /**
@@ -163,14 +160,8 @@ client.on('message', async (message) => {
     }
 });
 
-// Initialize client with self-healing retry.
-//
-// A failed Chromium launch (transient dbus race, resource contention at boot,
-// a stale profile lock) rejects the initialize() promise. Because the HTTP
-// server keeps listening on :3001, supervisord sees the process as "up" and
-// never restarts it — so without a retry here the bridge sits permanently
-// not-ready until a manual restart. Retry with backoff, cleaning up between
-// attempts, so a one-off launch failure self-heals instead of wedging the bridge.
+// Retry init with backoff so a transient Chromium launch failure self-heals.
+// The HTTP server stays up on :3001 either way, so supervisord won't restart us.
 const MAX_INIT_ATTEMPTS = parseInt(process.env.WHATSAPP_INIT_MAX_ATTEMPTS || '5', 10);
 const INIT_RETRY_BASE_MS = parseInt(process.env.WHATSAPP_INIT_RETRY_MS || '5000', 10);
 
@@ -187,9 +178,7 @@ async function initializeWithRetry(attempt = 1) {
             return;
         }
 
-        // A failed launch can leave a half-open browser and stale singleton
-        // lock files behind. Tear down and clean up so the next attempt starts
-        // from a clean profile.
+        // Clean up a half-open browser and stale locks before retrying.
         try { await client.destroy(); } catch (_) { /* browser may never have started */ }
         cleanupStaleLockFiles(SESSION_PATH);
 

--- a/src/integrations/whatsapp/bridge/server.js
+++ b/src/integrations/whatsapp/bridge/server.js
@@ -18,7 +18,11 @@ app.use(bodyParser.json({ limit: '50mb' }));
 const PORT = process.env.WHATSAPP_BRIDGE_PORT || 3001;
 const SESSION_PATH = process.env.WHATSAPP_SESSION_DIR || './whatsapp_session';
 const WEBHOOK_URL = process.env.WHATSAPP_WEBHOOK_URL || 'http://localhost:8080/api/whatsapp/webhook/incoming';
-const CHROMIUM_PATH = process.env.CHROMIUM_EXECUTABLE_PATH || '/usr/bin/chromium-browser';
+// Default matches the Debian `chromium` apt package installed in the Dockerfile
+// (/usr/bin/chromium, not chromium-browser) and launch-check.js. supervisord
+// sets CHROMIUM_EXECUTABLE_PATH explicitly; this fallback keeps the bridge
+// launchable if it's ever run without that env (e.g. locally or in CI).
+const CHROMIUM_PATH = process.env.CHROMIUM_EXECUTABLE_PATH || '/usr/bin/chromium';
 
 /**
  * Clean up stale Chromium lock files that prevent browser launch.
@@ -159,14 +163,43 @@ client.on('message', async (message) => {
     }
 });
 
-// Initialize client with error handling
-console.log('🔄 Initializing WhatsApp client...');
-client.initialize().catch((error) => {
-    console.error('❌ Failed to initialize WhatsApp client:', error);
-    console.error('Stack trace:', error.stack);
-    // Don't exit immediately - let supervisord handle retries
-    // The server will still be running but not ready
-});
+// Initialize client with self-healing retry.
+//
+// A failed Chromium launch (transient dbus race, resource contention at boot,
+// a stale profile lock) rejects the initialize() promise. Because the HTTP
+// server keeps listening on :3001, supervisord sees the process as "up" and
+// never restarts it — so without a retry here the bridge sits permanently
+// not-ready until a manual restart. Retry with backoff, cleaning up between
+// attempts, so a one-off launch failure self-heals instead of wedging the bridge.
+const MAX_INIT_ATTEMPTS = parseInt(process.env.WHATSAPP_INIT_MAX_ATTEMPTS || '5', 10);
+const INIT_RETRY_BASE_MS = parseInt(process.env.WHATSAPP_INIT_RETRY_MS || '5000', 10);
+
+async function initializeWithRetry(attempt = 1) {
+    try {
+        console.log(`🔄 Initializing WhatsApp client (attempt ${attempt}/${MAX_INIT_ATTEMPTS})...`);
+        await client.initialize();
+    } catch (error) {
+        console.error(`❌ Failed to initialize WhatsApp client (attempt ${attempt}/${MAX_INIT_ATTEMPTS}):`, error.message);
+        console.error('Stack trace:', error.stack);
+
+        if (attempt >= MAX_INIT_ATTEMPTS) {
+            console.error('❌ Exhausted WhatsApp init attempts; bridge HTTP API stays up but WhatsApp is not ready.');
+            return;
+        }
+
+        // A failed launch can leave a half-open browser and stale singleton
+        // lock files behind. Tear down and clean up so the next attempt starts
+        // from a clean profile.
+        try { await client.destroy(); } catch (_) { /* browser may never have started */ }
+        cleanupStaleLockFiles(SESSION_PATH);
+
+        const delay = INIT_RETRY_BASE_MS * attempt;
+        console.log(`⏳ Retrying WhatsApp init in ${delay}ms...`);
+        setTimeout(() => { initializeWithRetry(attempt + 1); }, delay);
+    }
+}
+
+initializeWithRetry();
 
 // ============================================================================
 // API ENDPOINTS


### PR DESCRIPTION
Follow-up hardening on the v1.2.1→1.2.4 startup regression. The core fix
(headless:'shell' + committed package-lock) is in place; verified empirically
that headless:'shell' launches system Chromium cleanly with no dbus socket
present, while headless:true (--headless=new) is what crashed with
"Failed to launch the browser process: Code: null" in the dbus-less container.

Three remaining gaps closed:

1. Self-healing init retry (server.js)
   A failed browser launch rejected initialize() but the HTTP server kept
   listening on :3001, so supervisord saw the process as "up" and never
   restarted it — the bridge sat permanently not-ready until a manual restart.
   initialize() now retries with backoff (5 attempts), destroying the client
   and clearing stale singleton lock files between attempts, so a transient
   launch failure self-heals. Tunable via WHATSAPP_INIT_MAX_ATTEMPTS /
   WHATSAPP_INIT_RETRY_MS.

2. Correct default Chromium path (server.js)
   Fallback was /usr/bin/chromium-browser, but the Dockerfile installs the
   Debian `chromium` package at /usr/bin/chromium (matching launch-check.js).
   The bridge now launches even if CHROMIUM_EXECUTABLE_PATH is unset.

3. Pin whatsapp-web.js exactly (package.json + lock)
   Was "^1.23.0", which is what let a stray npm install silently jump to
   1.34.7 and pull puppeteer 19→24 (the root cause). Pinned to 1.34.7 so the
   manifest can't drift even without the lockfile; dependency tree unchanged
   (puppeteer-core stays 24.38.0).

Verified: npm ci consistent, launch-check.js OK, all bridge HTTP endpoints
pass, and the retry path re-initializes cleanly (destroy→relaunch) without
crashing while /health stays 200.