### PR TITLE
fix(whatsapp): provide a DBus system bus so headless Chrome >=114 can…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,11 @@ jobs:
       - name: Test bridge HTTP server endpoints
         run: |
           BRIDGE_DIR="$(pwd)/src/integrations/whatsapp/bridge"
+          # Launch via start-bridge.sh so the DBus setup (needed for Chrome >=114)
+          # is exercised, matching how supervisord runs the bridge in production.
           CHROMIUM_EXECUTABLE_PATH="${{ steps.chromium.outputs.path }}" \
           WHATSAPP_SESSION_DIR="/tmp/wa-ci-session" \
-          node "$BRIDGE_DIR/server.js" > /tmp/bridge-server.log 2>&1 &
+          sh "$BRIDGE_DIR/start-bridge.sh" > /tmp/bridge-server.log 2>&1 &
           SERVER_PID=$!
 
           READY=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
         gnupg \
         supervisor \
         dumb-init \
+        dbus \
         chromium \
         chromium-sandbox \
         fonts-liberation \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-assistant"
-version = "1.2.5"
+version = "1.2.6"
 description = "AI-powered personal assistant for task automation and integration"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/integrations/whatsapp/bridge/start-bridge.sh
+++ b/src/integrations/whatsapp/bridge/start-bridge.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# WhatsApp bridge launcher.
+
+# Run from the bridge directory so `node server.js` resolves from any cwd.
+cd "$(dirname "$0")" || exit 1
+
+# Managed mode: the bridge isn't used, so exit cleanly.
+if [ -n "$MANAGED_API_KEY" ]; then
+    echo "WhatsApp bridge disabled in managed mode"
+    exit 0
+fi
+
+# Headless Chrome >=114 needs a DBus system bus to launch; without one it dies
+# with "Code: null". Start a private, user-owned bus and point Chrome at it.
+RUNTIME_DIR="/tmp/wa-bridge-runtime"
+DBUS_SOCK="$RUNTIME_DIR/dbus"
+DBUS_ADDR="unix:path=$DBUS_SOCK"
+if command -v dbus-daemon >/dev/null 2>&1; then
+    mkdir -p "$RUNTIME_DIR"
+    chmod 700 "$RUNTIME_DIR"
+    # dbus-daemon --session needs XDG_RUNTIME_DIR owned by us and mode 700.
+    export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+    rm -f "$DBUS_SOCK"
+    dbus-daemon --session --nofork --nopidfile --address="$DBUS_ADDR" &
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [ -S "$DBUS_SOCK" ] && break
+        sleep 0.2
+    done
+    if [ -S "$DBUS_SOCK" ]; then
+        export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_ADDR"
+        export DBUS_SESSION_BUS_ADDRESS="$DBUS_ADDR"
+        echo "🚌 DBus bus ready at $DBUS_ADDR"
+    else
+        echo "⚠️  DBus bus did not come up; continuing without it"
+    fi
+else
+    echo "⚠️  dbus-daemon not found; continuing without a DBus bus"
+fi
+
+exec node server.js

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -30,7 +30,7 @@ stderr_logfile_maxbytes=0
 environment=PATH="/app/.venv/bin:%(ENV_PATH)s",PYTHONPATH="/app"
 
 [program:whatsapp-bridge]
-command=/bin/sh -c "[ -n \"$MANAGED_API_KEY\" ] && { echo 'WhatsApp bridge disabled in managed mode'; exit 0; } || exec node server.js"
+command=/bin/sh /app/src/integrations/whatsapp/bridge/start-bridge.sh
 directory=/app/src/integrations/whatsapp/bridge
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
… launch

The real root cause of the "Failed to launch the browser process: Code: null" crash. The silent puppeteer 19->24 upgrade in 1.2.1 pulled a Chromium build (Chrome >=114) that connects to the DBus system bus during launch; the container has no bus, so Chrome aborts with a signal death. The dbus errors in the logs were the fatal cause, not noise — confirmed against puppeteer issues #10357/#10532/#11028/#11900. Prior fixes (headless mode, flags, PID1/dumb-init, lockfile, retry) treated symptoms; none provided a bus, so every launch attempt still died — including all five retry attempts in production.

Fix: start-bridge.sh launches a private, user-owned DBus bus before the bridge and points Chrome at it via DBUS_SYSTEM_BUS_ADDRESS. No root or host DBus needed — it runs as the existing non-root user, so the container's security model is unchanged. Best-effort: if the bus can't start, the bridge still launches.

- start-bridge.sh: new launcher (also folds in the managed-mode skip); starts dbus-daemon with a custom address under a self-owned XDG_RUNTIME_DIR so it works as uid 1000, waits for the socket, exports the bus address, then execs the server.
- Dockerfile: install the `dbus` package (provides dbus-daemon).
- supervisord.conf: run the bridge via start-bridge.sh.
- ci.yml: launch the bridge through start-bridge.sh so the DBus path is covered.
- bump to v1.2.6.