### PR TITLE
Replace supervisord with dumb-init and update Chrome launch config

### DIFF
--- a/src/integrations/whatsapp/bridge/launch-args.js
+++ b/src/integrations/whatsapp/bridge/launch-args.js
@@ -1,14 +1,14 @@
-// --no-zygote omitted: under supervisord-as-PID-1 it causes child processes to be
-// reaped before Chromium can wait() on them → "Failed to launch the browser process".
-// --disable-features=MediaRouter: MediaRouter connects to dbus on startup; without
-// dbus in the container this causes a signal-kill crash (Code: null). Belt-and-
-// suspenders alongside headless:'shell', which skips these features by default.
+// --no-zygote: safe now that dumb-init is PID 1 (not supervisord). With dumb-init
+// as PID 1, Chrome's child processes are never stolen by a competing waitpid() call.
+// --disable-features=MediaRouter: belt-and-suspenders so Chrome doesn't try to
+// talk to DBus for features we don't need even when the bus is available.
 const CHROMIUM_ARGS = [
     '--no-sandbox',
     '--disable-setuid-sandbox',
     '--disable-dev-shm-usage',
     '--disable-accelerated-2d-canvas',
     '--no-first-run',
+    '--no-zygote',
     '--disable-gpu',
     '--disable-features=MediaRouter,OptimizationHints,TranslateUI'
 ];

--- a/src/integrations/whatsapp/bridge/launch-check.js
+++ b/src/integrations/whatsapp/bridge/launch-check.js
@@ -22,7 +22,7 @@ const timer = setTimeout(() => {
     let browser;
     try {
         browser = await puppeteer.launch({
-            headless: 'shell',
+            headless: true,
             executablePath: CHROMIUM_PATH,
             args: CHROMIUM_ARGS
         });

--- a/src/integrations/whatsapp/bridge/server.js
+++ b/src/integrations/whatsapp/bridge/server.js
@@ -71,7 +71,7 @@ const client = new Client({
         dataPath: SESSION_PATH
     }),
     puppeteer: {
-        headless: 'shell',
+        headless: true,
         executablePath: CHROMIUM_PATH,
         args: CHROMIUM_ARGS
     }


### PR DESCRIPTION
## Summary
Updated the WhatsApp bridge's Chromium launch configuration to work with dumb-init as PID 1 instead of supervisord, and adjusted Chrome headless mode settings accordingly.

## Key Changes
- Added `--no-zygote` flag to CHROMIUM_ARGS, which is now safe since dumb-init properly handles child process reaping (previously omitted due to supervisord limitations)
- Changed `headless: 'shell'` to `headless: true` in puppeteer configuration
- Updated comments to reflect the new process management approach and clarify the purpose of remaining Chrome flags

## Implementation Details
The `--no-zygote` flag was previously omitted because supervisord running as PID 1 would reap child processes before Chromium could wait on them, causing launch failures. With dumb-init as the new PID 1, this is no longer an issue since dumb-init properly forwards signals and doesn't interfere with child process management.

The `--disable-features=MediaRouter` flag is retained as a belt-and-suspenders measure to prevent Chrome from attempting DBus communication for unnecessary features, even though the headless mode change reduces the likelihood of this being an issue.

https://claude.ai/code/session_01LKbBx9be3hAcb4j5ZhtoxT