### PR TITLE
Add short navbar brand text for mobile view

### DIFF
--- a/src/ui/static/artifacts.html
+++ b/src/ui/static/artifacts.html
@@ -170,6 +170,7 @@
             <div class="navbar-brand">
                 <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
                 <span>Open Assistant</span>
+                <span class="navbar-brand-short">OA</span>
             </div>
             <div class="navbar-links">
                 <a href="/" class="nav-link">Chat</a>

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -111,6 +111,10 @@ body {
     height: 32px;
 }
 
+.navbar-brand-short {
+    display: none;
+}
+
 .navbar-links {
     display: flex;
     gap: 8px;

--- a/src/ui/static/css/mobile.css
+++ b/src/ui/static/css/mobile.css
@@ -197,7 +197,7 @@ body.is-pwa {
         display: none;
     }
 
-    .navbar-brand-short {
+    .navbar-brand .navbar-brand-short {
         display: inline;
     }
 

--- a/src/ui/static/css/mobile.css
+++ b/src/ui/static/css/mobile.css
@@ -197,6 +197,10 @@ body.is-pwa {
         display: none;
     }
 
+    .navbar-brand-short {
+        display: inline;
+    }
+
     /* Show hamburger, hide inline links */
     .navbar-hamburger {
         display: flex;

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -326,6 +326,7 @@
             <div class="navbar-brand">
                 <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
                 <span>Open Assistant</span>
+                <span class="navbar-brand-short">OA</span>
             </div>
             <div class="navbar-links">
                 <a href="/" class="nav-link">Chat</a>

--- a/src/ui/static/monitoring.html
+++ b/src/ui/static/monitoring.html
@@ -393,6 +393,7 @@
             <div class="navbar-brand">
                 <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
                 <span>Open Assistant</span>
+                <span class="navbar-brand-short">OA</span>
             </div>
             <div class="navbar-links">
                 <a href="/" class="nav-link">Chat</a>

--- a/src/ui/static/settings.html
+++ b/src/ui/static/settings.html
@@ -44,6 +44,7 @@
             <div class="navbar-brand">
                 <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
                 <span>Open Assistant</span>
+                <span class="navbar-brand-short">OA</span>
             </div>
             <div class="navbar-links">
                 <a href="/" class="nav-link">Chat</a>


### PR DESCRIPTION
## Summary
This PR adds a responsive navbar brand display that shows a shortened "OA" text on mobile devices while maintaining the full "Open Assistant" text on desktop.

## Key Changes
- Added `.navbar-brand-short` CSS class hidden by default on desktop (`display: none`)
- Made `.navbar-brand-short` visible on mobile devices (`display: inline`)
- Added `<span class="navbar-brand-short">OA</span>` to the navbar brand in the HTML markup

## Implementation Details
The solution uses CSS media queries (via the existing `mobile.css` stylesheet) to conditionally display the shortened brand text only on mobile viewports. This allows the navbar to maintain a compact appearance on smaller screens while preserving the full branding on desktop. The short text "OA" serves as an abbreviation for "Open Assistant" and helps reduce horizontal space consumption in the mobile navigation bar.