### PR TITLE
Add native array parameter type support to plugin endpoints

### DIFF
--- a/docs/plugin-schema.md
+++ b/docs/plugin-schema.md
@@ -126,7 +126,8 @@ Each endpoint becomes one LLM tool named `plugin_{id}_{endpoint.name}`.
 |---|---|---|---|
 | `name` | string | ✅ | Parameter name. |
 | `in` | `"path"` \| `"query"` \| `"body"` \| `"header"` | ✅ | Where the parameter is placed. |
-| `type` | `"string"` \| `"integer"` \| `"number"` \| `"boolean"` | ✅ | JSON Schema type. |
+| `type` | `"string"` \| `"integer"` \| `"number"` \| `"boolean"` \| `"array"` | ✅ | JSON Schema type. Use `array` for a list of primitives (see below). |
+| `items` | object | required **when** `type = "array"` | Describes the array element type: `{ "type": "<primitive>" }`. |
 | `description` | string | ✅ | Description shown to the LLM. |
 | `required` | boolean | | Default: `true`. |
 | `default` | any | | Default value when not provided. |
@@ -139,6 +140,43 @@ Each endpoint becomes one LLM tool named `plugin_{id}_{endpoint.name}`.
 | `query` | Appended as `?name=value` |
 | `body` | Included in the JSON request body |
 | `header` | Added as an HTTP request header |
+
+#### Array parameters
+
+Set `type: "array"` when the target API expects a JSON array (e.g. a list of
+IDs in the request body). Pair it with an `items` object describing the element
+type — one of `string`, `integer`, `number`, or `boolean`:
+
+```json
+{
+  "name": "social_accounts",
+  "in": "body",
+  "type": "array",
+  "items": { "type": "integer" },
+  "description": "Numeric social account IDs to post to.",
+  "required": true
+}
+```
+
+Serialization depends on placement:
+
+| `in` | Serialization |
+|---|---|
+| `body` | Native JSON array in the request body: `"social_accounts": [75205, 75209]` |
+| `query` | Repeated query params: `?type=image&type=video` |
+
+**Rules:**
+
+- `items` is required **if and only if** `type` is `array`. Declaring `array`
+  without `items`, or supplying `items` on a non-array parameter, is rejected
+  with a descriptive error.
+- `items.type` must be one of the four primitives. Nested arrays and objects
+  are not supported in this iteration.
+- Array parameters are only meaningful for `in: "body"` and `in: "query"`.
+  `path` and `header` placements reject `type: "array"`.
+
+Because the tool schema advertises a real array type, the model emits an actual
+JSON array — no stringified `"[75205]"` workaround, and no runtime coercion.
 
 ---
 

--- a/src/models/plugin.py
+++ b/src/models/plugin.py
@@ -48,7 +48,7 @@ class PluginEndpointParameter(BaseModel):
                 raise ValueError(
                     f"Parameter '{self.name}' has type 'array' but is missing the required "
                     f"'items' field describing the element type "
-                    f"(e.g. \"items\": {{\"type\": \"integer\"}})."
+                    f'(e.g. "items": {{"type": "integer"}}).'
                 )
             if self.in_ in ("path", "header"):
                 raise ValueError(

--- a/src/models/plugin.py
+++ b/src/models/plugin.py
@@ -2,20 +2,67 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# Primitive parameter types (also the allowed element types for arrays).
+PARAM_PRIMITIVE_TYPES = {"string", "integer", "number", "boolean"}
+# Full set of allowed parameter types (primitives + array).
+PARAM_TYPES = PARAM_PRIMITIVE_TYPES | {"array"}
+
+
+class PluginParameterItems(BaseModel):
+    """Element-type descriptor for an ``array``-typed parameter.
+
+    Only single-level arrays of primitives are supported; nested arrays and
+    objects are intentionally disallowed for now.
+    """
+
+    type: Literal["string", "integer", "number", "boolean"]
 
 
 class PluginEndpointParameter(BaseModel):
     """A parameter for a plugin endpoint."""
 
     name: str
-    type: str = "string"  # "string", "integer", "number", "boolean"
+    type: str = "string"  # "string", "integer", "number", "boolean", "array"
     description: str
     required: bool = True
     in_: str = Field("query", alias="in")  # "path", "query", "body", "header"
     default: Optional[Any] = None
+    # Required when type == "array"; describes the array element type.
+    items: Optional[PluginParameterItems] = None
 
     model_config = {"populate_by_name": True}
+
+    @model_validator(mode="after")
+    def _validate_type_and_items(self) -> "PluginEndpointParameter":
+        if self.type not in PARAM_TYPES:
+            allowed = ", ".join(sorted(PARAM_TYPES))
+            raise ValueError(
+                f"Parameter '{self.name}' has invalid type '{self.type}'. "
+                f"Must be one of: {allowed}."
+            )
+
+        if self.type == "array":
+            if self.items is None:
+                raise ValueError(
+                    f"Parameter '{self.name}' has type 'array' but is missing the required "
+                    f"'items' field describing the element type "
+                    f"(e.g. \"items\": {{\"type\": \"integer\"}})."
+                )
+            if self.in_ in ("path", "header"):
+                raise ValueError(
+                    f"Parameter '{self.name}' has type 'array' with in='{self.in_}', which is "
+                    f"not supported. Array parameters are only meaningful for in='body' "
+                    f"(JSON array in the request body) or in='query' (repeated query params)."
+                )
+        elif self.items is not None:
+            raise ValueError(
+                f"Parameter '{self.name}' defines 'items' but its type is '{self.type}', not "
+                f"'array'. The 'items' field is only allowed when type is 'array'."
+            )
+
+        return self
 
 
 class PluginEndpoint(BaseModel):

--- a/src/plugins/plugin_schema.json
+++ b/src/plugins/plugin_schema.json
@@ -155,8 +155,21 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["string", "integer", "number", "boolean"],
-                  "description": "JSON Schema type for the parameter."
+                  "enum": ["string", "integer", "number", "boolean", "array"],
+                  "description": "JSON Schema type for the parameter. Use 'array' for a list of primitives; pair it with an 'items' field describing the element type."
+                },
+                "items": {
+                  "type": "object",
+                  "required": ["type"],
+                  "additionalProperties": false,
+                  "description": "Required when type is 'array'. Describes the array element type. Nested arrays/objects are not supported.",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["string", "integer", "number", "boolean"],
+                      "description": "Element type of the array. Must be a primitive."
+                    }
+                  }
                 },
                 "description": {
                   "type": "string",
@@ -169,7 +182,27 @@
                 "default": {
                   "description": "Default value when the parameter is not provided."
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "properties": { "type": { "const": "array" } },
+                    "required": ["type"]
+                  },
+                  "then": {
+                    "required": ["items"],
+                    "properties": {
+                      "in": {
+                        "enum": ["query", "body"],
+                        "description": "Array parameters are only supported for in='query' or in='body'."
+                      }
+                    }
+                  },
+                  "else": {
+                    "not": { "required": ["items"] }
+                  }
+                }
+              ]
             }
           }
         }

--- a/src/services/plugin_service.py
+++ b/src/services/plugin_service.py
@@ -137,6 +137,13 @@ class PluginService(BaseService):
                 prop["type"] = "number"
             elif param.type == "boolean":
                 prop["type"] = "boolean"
+            elif param.type == "array":
+                # Emit a proper JSON-Schema array so the model returns a real
+                # array instead of a stringified one. ``items`` is guaranteed
+                # present for array params by PluginEndpointParameter validation.
+                prop["type"] = "array"
+                element_type = param.items.type if param.items else "string"
+                prop["items"] = {"type": element_type}
             else:
                 prop["type"] = "string"
 

--- a/tests/test_plugin_array_params.py
+++ b/tests/test_plugin_array_params.py
@@ -1,0 +1,345 @@
+"""Tests for native ``array`` parameter type support in plugin endpoints.
+
+Covers:
+- The Pydantic model accepts ``type: "array"`` with a valid ``items`` block.
+- Validation rejects array-without-items, items-on-non-array, bad element
+  types, and array on path/header placements — each with a readable message.
+- Tool-schema generation emits a real JSON-Schema array (``type: array`` +
+  ``items``) so the LLM emits an array, not a stringified one.
+- Body array parameters serialize to a native JSON array in the outbound
+  request; query array parameters serialize as repeated query params.
+- Existing primitive-only parameters are unaffected.
+"""
+
+import json
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.plugin import (
+    PARAM_TYPES,
+    PluginDefinition,
+    PluginEndpointParameter,
+)
+from src.services.plugin_service import PluginService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plugin_service() -> PluginService:
+    settings_repo = MagicMock()
+    settings_repo.get.return_value = None
+    credentials_repo = MagicMock()
+    credentials_repo.get.return_value = None
+    return PluginService(
+        settings_repo=settings_repo,
+        credentials_repo=credentials_repo,
+        data_dir="/tmp",
+    )
+
+
+def _array_plugin_dict(param_in: str = "body") -> Dict[str, Any]:
+    """A minimal plugin whose single endpoint takes array params."""
+    return {
+        "id": "array_test",
+        "display_name": "Array Test",
+        "description": "Plugin exercising array parameter types.",
+        "base_url": "https://api.example.com",
+        "auth": {"type": "bearer"},
+        "endpoints": [
+            {
+                "name": "create_post",
+                "display_name": "Create Post",
+                "description": "Create a post across social accounts.",
+                "method": "POST",
+                "path": "/v1/posts",
+                "parameters": [
+                    {
+                        "name": "caption",
+                        "in": param_in,
+                        "type": "string",
+                        "description": "Post caption.",
+                        "required": True,
+                    },
+                    {
+                        "name": "social_accounts",
+                        "in": param_in,
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "Numeric social account IDs.",
+                        "required": True,
+                    },
+                    {
+                        "name": "media_urls",
+                        "in": param_in,
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Media URLs.",
+                        "required": False,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestArrayParameterValidation:
+    def test_array_in_param_types(self):
+        assert "array" in PARAM_TYPES
+
+    def test_valid_array_param_accepted(self):
+        param = PluginEndpointParameter.model_validate(
+            {
+                "name": "ids",
+                "in": "body",
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "IDs.",
+            }
+        )
+        assert param.type == "array"
+        assert param.items is not None
+        assert param.items.type == "integer"
+
+    def test_full_plugin_with_array_params_validates(self):
+        defn = PluginDefinition.model_validate(_array_plugin_dict("body"))
+        param = defn.endpoints[0].parameters[1]
+        assert param.type == "array"
+        assert param.items.type == "integer"
+
+    def test_array_without_items_rejected(self):
+        with pytest.raises(ValidationError, match="missing the required 'items'"):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "body",
+                    "type": "array",
+                    "description": "IDs.",
+                }
+            )
+
+    def test_items_on_non_array_rejected(self):
+        with pytest.raises(ValidationError, match="only allowed when type is 'array'"):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "body",
+                    "type": "string",
+                    "items": {"type": "integer"},
+                    "description": "IDs.",
+                }
+            )
+
+    def test_invalid_element_type_rejected(self):
+        with pytest.raises(ValidationError):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "body",
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "IDs.",
+                }
+            )
+
+    def test_nested_array_element_type_rejected(self):
+        with pytest.raises(ValidationError):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "body",
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": "IDs.",
+                }
+            )
+
+    def test_invalid_param_type_rejected(self):
+        with pytest.raises(ValidationError, match="invalid type 'object'"):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "blob",
+                    "in": "body",
+                    "type": "object",
+                    "description": "Blob.",
+                }
+            )
+
+    def test_array_in_path_rejected(self):
+        with pytest.raises(ValidationError, match="not supported"):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "path",
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "IDs.",
+                }
+            )
+
+    def test_array_in_header_rejected(self):
+        with pytest.raises(ValidationError, match="not supported"):
+            PluginEndpointParameter.model_validate(
+                {
+                    "name": "ids",
+                    "in": "header",
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "IDs.",
+                }
+            )
+
+    def test_array_in_query_accepted(self):
+        param = PluginEndpointParameter.model_validate(
+            {
+                "name": "types",
+                "in": "query",
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Types.",
+            }
+        )
+        assert param.type == "array"
+
+
+# ---------------------------------------------------------------------------
+# Tool-schema generation
+# ---------------------------------------------------------------------------
+
+
+class TestArrayToolSchema:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+
+    def _build_schema(self, param_in: str = "body") -> Dict[str, Any]:
+        defn = PluginDefinition.model_validate(_array_plugin_dict(param_in))
+        tool = self.svc._create_tool("array_test", defn, defn.endpoints[0])
+        return tool.schema.parameters
+
+    def test_array_param_emits_json_schema_array(self):
+        props = self._build_schema()["properties"]
+        assert props["social_accounts"]["type"] == "array"
+        assert props["social_accounts"]["items"] == {"type": "integer"}
+
+    def test_string_array_items_type(self):
+        props = self._build_schema()["properties"]
+        assert props["media_urls"]["type"] == "array"
+        assert props["media_urls"]["items"] == {"type": "string"}
+
+    def test_primitive_param_has_no_items(self):
+        props = self._build_schema()["properties"]
+        assert props["caption"]["type"] == "string"
+        assert "items" not in props["caption"]
+
+    def test_required_list_reflects_required_flag(self):
+        schema = self._build_schema()
+        assert "social_accounts" in schema["required"]
+        assert "media_urls" not in schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime serialization
+# ---------------------------------------------------------------------------
+
+
+class TestArraySerialization:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+
+    def _install_array_plugin(self, param_in: str = "body"):
+        defn = PluginDefinition.model_validate(_array_plugin_dict(param_in))
+        self.svc._definitions["array_test"] = defn
+        self.svc.credentials_repo.get.return_value = {
+            "credential_data": {"token": "fake-token"}
+        }
+
+    def _make_mock_response(self):
+        resp = MagicMock()
+        resp.content = b'{"id": 1}'
+        resp.json.return_value = {"id": 1}
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    async def _run(self, param_in: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        self._install_array_plugin(param_in)
+        captured: Dict[str, Any] = {}
+
+        async def fake_request(**kwargs):
+            captured.update(kwargs)
+            return self._make_mock_response()
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(side_effect=fake_request)
+            mock_cls.return_value = mock_client
+
+            await self.svc._execute_endpoint("array_test", "create_post", arguments)
+
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_body_array_is_native_json_array(self):
+        captured = await self._run(
+            "body",
+            {"caption": "hi", "social_accounts": [75205, 75209]},
+        )
+        # httpx json= receives the raw Python structure
+        assert captured["json"]["social_accounts"] == [75205, 75209]
+        assert isinstance(captured["json"]["social_accounts"], list)
+        # And it serializes to a genuine JSON array, not a quoted string
+        serialized = json.dumps(captured["json"])
+        assert '"social_accounts": [75205, 75209]' in serialized
+        assert '"[75205' not in serialized
+
+    @pytest.mark.asyncio
+    async def test_query_array_is_list(self):
+        captured = await self._run(
+            "query",
+            {"caption": "hi", "media_urls": ["a.png", "b.png"]},
+        )
+        # httpx serializes a list value as repeated query params.
+        assert captured["params"]["media_urls"] == ["a.png", "b.png"]
+
+    @pytest.mark.asyncio
+    async def test_single_element_array_stays_array(self):
+        captured = await self._run(
+            "body",
+            {"caption": "hi", "social_accounts": [75205]},
+        )
+        assert captured["json"]["social_accounts"] == [75205]
+        assert isinstance(captured["json"]["social_accounts"], list)
+
+
+# ---------------------------------------------------------------------------
+# Existing built-in plugins remain unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+
+    def test_builtins_still_load(self):
+        assert {"azure_devops", "toggl", "wordpress"}.issubset(self.svc._definitions)
+
+    def test_primitive_params_generate_unchanged_schema(self):
+        toggl = self.svc._definitions["toggl"]
+        for ep in toggl.endpoints:
+            tool = self.svc._create_tool("toggl", toggl, ep)
+            for prop in tool.schema.parameters["properties"].values():
+                # No primitive param should ever carry an items block.
+                assert "items" not in prop
+                assert prop["type"] in {"string", "integer", "number", "boolean"}

--- a/tests/test_plugin_array_params.py
+++ b/tests/test_plugin_array_params.py
@@ -25,7 +25,6 @@ from src.models.plugin import (
 )
 from src.services.plugin_service import PluginService
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -259,9 +258,7 @@ class TestArraySerialization:
     def _install_array_plugin(self, param_in: str = "body"):
         defn = PluginDefinition.model_validate(_array_plugin_dict(param_in))
         self.svc._definitions["array_test"] = defn
-        self.svc.credentials_repo.get.return_value = {
-            "credential_data": {"token": "fake-token"}
-        }
+        self.svc.credentials_repo.get.return_value = {"credential_data": {"token": "fake-token"}}
 
     def _make_mock_response(self):
         resp = MagicMock()

--- a/tests/test_plugin_array_params.py
+++ b/tests/test_plugin_array_params.py
@@ -43,7 +43,11 @@ def _make_plugin_service() -> PluginService:
 
 
 def _array_plugin_dict(param_in: str = "body") -> Dict[str, Any]:
-    """A minimal plugin whose single endpoint takes array params."""
+    """A minimal, domain-neutral plugin whose endpoint takes array params.
+
+    ``tag_ids`` exercises an integer-element array and ``labels`` a
+    string-element array; ``title`` is a plain primitive for contrast.
+    """
     return {
         "id": "array_test",
         "display_name": "Array Test",
@@ -52,33 +56,33 @@ def _array_plugin_dict(param_in: str = "body") -> Dict[str, Any]:
         "auth": {"type": "bearer"},
         "endpoints": [
             {
-                "name": "create_post",
-                "display_name": "Create Post",
-                "description": "Create a post across social accounts.",
+                "name": "create_item",
+                "display_name": "Create Item",
+                "description": "Create a record that references multiple tags and labels.",
                 "method": "POST",
-                "path": "/v1/posts",
+                "path": "/v1/items",
                 "parameters": [
                     {
-                        "name": "caption",
+                        "name": "title",
                         "in": param_in,
                         "type": "string",
-                        "description": "Post caption.",
+                        "description": "Item title.",
                         "required": True,
                     },
                     {
-                        "name": "social_accounts",
+                        "name": "tag_ids",
                         "in": param_in,
                         "type": "array",
                         "items": {"type": "integer"},
-                        "description": "Numeric social account IDs.",
+                        "description": "Numeric tag IDs to associate.",
                         "required": True,
                     },
                     {
-                        "name": "media_urls",
+                        "name": "labels",
                         "in": param_in,
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Media URLs.",
+                        "description": "Free-text labels.",
                         "required": False,
                     },
                 ],
@@ -201,11 +205,11 @@ class TestArrayParameterValidation:
     def test_array_in_query_accepted(self):
         param = PluginEndpointParameter.model_validate(
             {
-                "name": "types",
+                "name": "kinds",
                 "in": "query",
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Types.",
+                "description": "Kinds.",
             }
         )
         assert param.type == "array"
@@ -225,25 +229,25 @@ class TestArrayToolSchema:
         tool = self.svc._create_tool("array_test", defn, defn.endpoints[0])
         return tool.schema.parameters
 
-    def test_array_param_emits_json_schema_array(self):
+    def test_integer_array_emits_json_schema_array(self):
         props = self._build_schema()["properties"]
-        assert props["social_accounts"]["type"] == "array"
-        assert props["social_accounts"]["items"] == {"type": "integer"}
+        assert props["tag_ids"]["type"] == "array"
+        assert props["tag_ids"]["items"] == {"type": "integer"}
 
     def test_string_array_items_type(self):
         props = self._build_schema()["properties"]
-        assert props["media_urls"]["type"] == "array"
-        assert props["media_urls"]["items"] == {"type": "string"}
+        assert props["labels"]["type"] == "array"
+        assert props["labels"]["items"] == {"type": "string"}
 
     def test_primitive_param_has_no_items(self):
         props = self._build_schema()["properties"]
-        assert props["caption"]["type"] == "string"
-        assert "items" not in props["caption"]
+        assert props["title"]["type"] == "string"
+        assert "items" not in props["title"]
 
     def test_required_list_reflects_required_flag(self):
         schema = self._build_schema()
-        assert "social_accounts" in schema["required"]
-        assert "media_urls" not in schema["required"]
+        assert "tag_ids" in schema["required"]
+        assert "labels" not in schema["required"]
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +287,7 @@ class TestArraySerialization:
             mock_client.request = AsyncMock(side_effect=fake_request)
             mock_cls.return_value = mock_client
 
-            await self.svc._execute_endpoint("array_test", "create_post", arguments)
+            await self.svc._execute_endpoint("array_test", "create_item", arguments)
 
         return captured
 
@@ -291,33 +295,33 @@ class TestArraySerialization:
     async def test_body_array_is_native_json_array(self):
         captured = await self._run(
             "body",
-            {"caption": "hi", "social_accounts": [75205, 75209]},
+            {"title": "hi", "tag_ids": [11, 22]},
         )
         # httpx json= receives the raw Python structure
-        assert captured["json"]["social_accounts"] == [75205, 75209]
-        assert isinstance(captured["json"]["social_accounts"], list)
+        assert captured["json"]["tag_ids"] == [11, 22]
+        assert isinstance(captured["json"]["tag_ids"], list)
         # And it serializes to a genuine JSON array, not a quoted string
         serialized = json.dumps(captured["json"])
-        assert '"social_accounts": [75205, 75209]' in serialized
-        assert '"[75205' not in serialized
+        assert '"tag_ids": [11, 22]' in serialized
+        assert '"[11' not in serialized
 
     @pytest.mark.asyncio
     async def test_query_array_is_list(self):
         captured = await self._run(
             "query",
-            {"caption": "hi", "media_urls": ["a.png", "b.png"]},
+            {"title": "hi", "labels": ["alpha", "beta"]},
         )
         # httpx serializes a list value as repeated query params.
-        assert captured["params"]["media_urls"] == ["a.png", "b.png"]
+        assert captured["params"]["labels"] == ["alpha", "beta"]
 
     @pytest.mark.asyncio
     async def test_single_element_array_stays_array(self):
         captured = await self._run(
             "body",
-            {"caption": "hi", "social_accounts": [75205]},
+            {"title": "hi", "tag_ids": [11]},
         )
-        assert captured["json"]["social_accounts"] == [75205]
-        assert isinstance(captured["json"]["social_accounts"], list)
+        assert captured["json"]["tag_ids"] == [11]
+        assert isinstance(captured["json"]["tag_ids"], list)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds first-class support for array-typed parameters in plugin endpoint definitions. Plugin authors can now declare parameters with `type: "array"` paired with an `items` field describing the element type, enabling the LLM to emit native JSON arrays instead of stringified workarounds.

## Key Changes

- **Model validation** (`src/models/plugin.py`):
  - Added `PluginParameterItems` model to describe array element types (primitives only)
  - Extended `PluginEndpointParameter` with optional `items` field
  - Introduced `PARAM_TYPES` and `PARAM_PRIMITIVE_TYPES` constants
  - Added comprehensive validation: arrays require `items`, `items` only allowed on arrays, element types must be primitives, arrays rejected for `path`/`header` placements

- **Tool schema generation** (`src/services/plugin_service.py`):
  - Updated `_create_tool()` to emit proper JSON-Schema array syntax (`type: "array"` + `items`) so the LLM generates actual arrays, not stringified representations

- **Documentation** (`docs/plugin-schema.md`):
  - Added array parameter section with examples and serialization rules
  - Documented placement-dependent behavior: body arrays serialize as native JSON, query arrays as repeated params

- **Schema definition** (`src/plugins/plugin_schema.json`):
  - Updated parameter schema to include `items` field with conditional validation
  - Added JSON-Schema `allOf` constraints: `items` required when `type="array"`, array placement restricted to `query`/`body`

- **Comprehensive test coverage** (`tests/test_plugin_array_params.py`):
  - Model validation tests covering valid arrays, missing/invalid `items`, invalid element types, placement restrictions
  - Tool schema generation tests verifying proper JSON-Schema array emission
  - Runtime serialization tests confirming native JSON arrays in body and repeated query params
  - Backward compatibility tests ensuring existing primitive-only parameters and built-in plugins remain unaffected

## Implementation Details

- Only single-level arrays of primitives are supported; nested arrays and objects are intentionally disallowed
- Validation provides clear, actionable error messages for common mistakes
- Array serialization is automatic: body arrays become native JSON, query arrays become repeated params
- All existing functionality remains unchanged; this is purely additive
