### PR TITLE
Fix calendar 400 by normalizing loose date terms for Graph filter

### DIFF
--- a/src/models/outlook.py
+++ b/src/models/outlook.py
@@ -35,11 +35,11 @@ class ListEventsRequest(BaseModel):
     )
     start_date: Optional[str] = Field(
         None,
-        description="Start date filter (ISO format, e.g. 2026-01-01T00:00:00). If not specified, defaults to current time. For 'today' queries, use start of today (e.g. 2026-01-15T00:00:00).",
+        description="Start date filter. Accepts ISO-8601 (e.g. 2026-01-01T00:00:00) or relative terms like 'today', 'tomorrow', 'yesterday', 'now', 'this week'. If not specified, defaults to the current time.",
     )
     end_date: Optional[str] = Field(
         None,
-        description="End date filter (ISO format, e.g. 2026-01-01T23:59:59). Always set this to scope the query to the relevant period. For 'today' queries, use end of today (e.g. 2026-01-15T23:59:59).",
+        description="End date filter. Accepts ISO-8601 (e.g. 2026-01-01T23:59:59) or relative terms like 'today', 'tomorrow', 'this week'. Always set this to scope the query to the relevant period; relative terms and bare dates resolve to end-of-day.",
     )
     limit: int = Field(
         10, description="Maximum events. Use 25 for a single day, 50 for a week.", ge=1, le=100

--- a/src/services/outlook.py
+++ b/src/services/outlook.py
@@ -1,8 +1,10 @@
 """Outlook service for email, calendar, and OneDrive operations."""
 
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
+
+from dateutil import parser as dateutil_parser
 
 from src.core.repositories.audit import AuditLogRepository
 from src.core.repositories.credentials import CredentialsRepository
@@ -18,6 +20,91 @@ from src.services.base import BaseService
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_GRAPH_DATETIME_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+def _apply_boundary(dt: datetime, boundary: str) -> datetime:
+    """Apply a time-of-day to a bare date based on the filter boundary."""
+    if boundary == "end":
+        return dt.replace(hour=23, minute=59, second=59, microsecond=0)
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _normalize_calendar_date(value: Optional[str], boundary: str = "start") -> Optional[str]:
+    """Normalize a loose date term into a Graph-compatible ISO-8601 string.
+
+    Microsoft Graph's OData ``$filter`` requires a strict ISO-8601 datetime
+    (e.g. ``2026-07-15T00:00:00``). LLM tool calls frequently pass relative
+    terms like ``"today"`` instead, which Graph rejects with a 400. This helper
+    converts those terms into the exact format the calendar filter expects.
+
+    Handles relative keywords (``now``, ``today``, ``tomorrow``, ``yesterday``,
+    ``this week``) and any ``dateutil``-parsable date/datetime. Bare dates get a
+    time-of-day from ``boundary``: ``"start"`` -> ``00:00:00``,
+    ``"end"`` -> ``23:59:59``.
+
+    Args:
+        value: The date string to normalize. ``None`` is passed through.
+        boundary: ``"start"`` or ``"end"`` — controls the time-of-day applied to
+            bare dates and relative keywords.
+
+    Returns:
+        A ``"YYYY-MM-DDTHH:MM:SS"`` string (no timezone suffix, matching the
+        existing filter format), or ``None`` if ``value`` is ``None``.
+
+    Raises:
+        ValueError: If the value cannot be parsed into a date.
+    """
+    if value is None:
+        return None
+
+    raw = value.strip()
+    if not raw:
+        return None
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    keyword = raw.lower()
+
+    # Relative keywords that dateutil cannot parse on its own.
+    if keyword == "now":
+        return now.strftime(_GRAPH_DATETIME_FMT)
+    if keyword == "today":
+        return _apply_boundary(now, boundary).strftime(_GRAPH_DATETIME_FMT)
+    if keyword == "tomorrow":
+        return _apply_boundary(now + timedelta(days=1), boundary).strftime(_GRAPH_DATETIME_FMT)
+    if keyword == "yesterday":
+        return _apply_boundary(now - timedelta(days=1), boundary).strftime(_GRAPH_DATETIME_FMT)
+    if keyword in ("this week", "week"):
+        target = now if boundary == "start" else now + timedelta(days=7)
+        return _apply_boundary(target, boundary).strftime(_GRAPH_DATETIME_FMT)
+
+    # Try strict ISO-8601 first (fast path, preserves explicit time-of-day).
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        # A bare date (e.g. "2026-07-15") parses to midnight — apply the
+        # end-of-day boundary so end filters cover the whole day.
+        if boundary == "end" and (dt.hour, dt.minute, dt.second) == (0, 0, 0) and "T" not in raw:
+            dt = _apply_boundary(dt, boundary)
+        return dt.strftime(_GRAPH_DATETIME_FMT)
+    except (ValueError, AttributeError):
+        pass
+
+    # Fall back to fuzzy natural-language parsing.
+    try:
+        dt = dateutil_parser.parse(raw, fuzzy=True)
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        return dt.strftime(_GRAPH_DATETIME_FMT)
+    except (ValueError, TypeError, OverflowError):
+        pass
+
+    raise ValueError(
+        f"Could not parse date '{value}'. Use ISO-8601 like "
+        f"'2026-07-15T00:00:00' or terms like 'today'/'tomorrow'."
+    )
 
 
 class OutlookService(BaseService):
@@ -133,9 +220,14 @@ class OutlookService(BaseService):
         """
         client = self._get_client()
 
-        # Default to current time if start_date not specified (show only future events)
+        # Default to current time if start_date not specified (show only future events).
+        # Otherwise normalize loose/relative terms (e.g. "today") into strict ISO-8601
+        # so Microsoft Graph's OData $filter accepts them instead of returning a 400.
         if start_date is None:
             start_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+        else:
+            start_date = _normalize_calendar_date(start_date, boundary="start")
+        end_date = _normalize_calendar_date(end_date, boundary="end")
 
         return client.list_events(
             start_date=start_date, end_date=end_date, limit=limit, calendar_id=calendar_id

--- a/tests/test_outlook_calendar_dates.py
+++ b/tests/test_outlook_calendar_dates.py
@@ -1,0 +1,127 @@
+"""Tests for calendar date normalization in the Outlook service.
+
+Regression coverage for the Microsoft Graph 400 caused by passing loose date
+terms (e.g. the literal string "today") straight into the OData ``$filter``.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.outlook import OutlookService, _normalize_calendar_date
+
+
+class TestNormalizeCalendarDate:
+    """Unit tests for the ``_normalize_calendar_date`` helper."""
+
+    def test_none_passes_through(self):
+        assert _normalize_calendar_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _normalize_calendar_date("   ") is None
+
+    def test_today_start_is_midnight(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert _normalize_calendar_date("today", "start") == f"{today}T00:00:00"
+
+    def test_today_end_is_end_of_day(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert _normalize_calendar_date("today", "end") == f"{today}T23:59:59"
+
+    def test_case_insensitive_keyword(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert _normalize_calendar_date("Today", "start") == f"{today}T00:00:00"
+
+    def test_tomorrow(self):
+        result = _normalize_calendar_date("tomorrow", "start")
+        today = datetime.now(timezone.utc).date()
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%S").date()
+        assert (parsed - today).days == 1
+
+    def test_yesterday(self):
+        result = _normalize_calendar_date("yesterday", "end")
+        today = datetime.now(timezone.utc).date()
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%S")
+        assert (parsed.date() - today).days == -1
+        assert (parsed.hour, parsed.minute, parsed.second) == (23, 59, 59)
+
+    def test_now_uses_current_time(self):
+        result = _normalize_calendar_date("now", "start")
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%S")
+        assert parsed.date() == datetime.now(timezone.utc).date()
+
+    def test_this_week_start_and_end_span_forward(self):
+        start = _normalize_calendar_date("this week", "start")
+        end = _normalize_calendar_date("this week", "end")
+        start_dt = datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+        end_dt = datetime.strptime(end, "%Y-%m-%dT%H:%M:%S")
+        assert (end_dt.date() - start_dt.date()).days == 7
+
+    def test_bare_iso_date_start(self):
+        assert _normalize_calendar_date("2026-07-15", "start") == "2026-07-15T00:00:00"
+
+    def test_bare_iso_date_end_covers_full_day(self):
+        assert _normalize_calendar_date("2026-07-15", "end") == "2026-07-15T23:59:59"
+
+    def test_full_iso_datetime_preserved(self):
+        assert _normalize_calendar_date("2026-07-15T09:30:00", "start") == "2026-07-15T09:30:00"
+
+    def test_iso_datetime_with_z_suffix(self):
+        assert _normalize_calendar_date("2026-07-15T09:30:00Z", "start") == "2026-07-15T09:30:00"
+
+    def test_full_iso_datetime_end_not_forced_to_end_of_day(self):
+        # An explicit time-of-day must be preserved, not overwritten to 23:59:59.
+        assert _normalize_calendar_date("2026-07-15T09:30:00", "end") == "2026-07-15T09:30:00"
+
+    def test_gibberish_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _normalize_calendar_date("not a date at all", "start")
+
+
+class TestListCalendarEventsNormalization:
+    """The service must never forward loose date terms to the Graph client."""
+
+    def _service_with_mock_client(self):
+        service = OutlookService(
+            settings_repo=MagicMock(),
+            credentials_repo=MagicMock(),
+        )
+        mock_client = MagicMock()
+        mock_client.list_events.return_value = []
+        return service, mock_client
+
+    def test_today_is_normalized_before_reaching_client(self):
+        service, mock_client = self._service_with_mock_client()
+        with patch.object(service, "_get_client", return_value=mock_client):
+            service.list_calendar_events(start_date="today", end_date="today")
+
+        kwargs = mock_client.list_events.call_args.kwargs
+        # The literal "today" must never be forwarded — that is what Graph 400s on.
+        assert kwargs["start_date"] != "today"
+        assert kwargs["end_date"] != "today"
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert kwargs["start_date"] == f"{today}T00:00:00"
+        assert kwargs["end_date"] == f"{today}T23:59:59"
+
+    def test_default_start_when_omitted(self):
+        service, mock_client = self._service_with_mock_client()
+        with patch.object(service, "_get_client", return_value=mock_client):
+            service.list_calendar_events()
+
+        kwargs = mock_client.list_events.call_args.kwargs
+        assert kwargs["start_date"] is not None
+        assert kwargs["end_date"] is None
+        # Default start_date is a valid ISO timestamp.
+        datetime.strptime(kwargs["start_date"], "%Y-%m-%dT%H:%M:%S")
+
+    def test_iso_input_passes_through_unchanged(self):
+        service, mock_client = self._service_with_mock_client()
+        with patch.object(service, "_get_client", return_value=mock_client):
+            service.list_calendar_events(
+                start_date="2026-07-15T00:00:00", end_date="2026-07-15T23:59:59"
+            )
+
+        kwargs = mock_client.list_events.call_args.kwargs
+        assert kwargs["start_date"] == "2026-07-15T00:00:00"
+        assert kwargs["end_date"] == "2026-07-15T23:59:59"


### PR DESCRIPTION
The Outlook calendar "list events" tool forwarded free-text date values
(e.g. the literal string "today") straight into Microsoft Graph's OData
$filter, producing `start/dateTime ge 'today'`, which Graph rejects with a
400 Bad Request. This surfaced when the agent gathered "today's" meetings
before creating OneNote notes, making it look like a OneNote failure.

Add `_normalize_calendar_date` in the Outlook service to convert relative
terms ("today", "tomorrow", "yesterday", "now", "this week") and loose/bare
dates into strict ISO-8601 before they reach the client, reusing the
dateutil-based parsing pattern already used in future_task. Bare dates and
relative terms resolve to start-of-day or end-of-day based on the filter
boundary. Unparseable input raises an actionable ValueError.

Also update the outlook_list_events tool schema descriptions to document
that relative terms are accepted, and add regression tests asserting the
literal "today" never reaches the Graph client.