### PR TITLE
Add restart requirement note to Slack integration setup docs

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -112,6 +112,8 @@ In Slack, invite the bot to any channel where you want it to listen:
 4. Click **Save Settings**
 5. Click **Test Connection** to verify
 
+> **Note:** After saving, you'll need to **restart your Open Assistant instance** for the Slack integration to start working.
+
 ---
 
 ## Setup: HTTP Webhooks (Alternative)
@@ -187,6 +189,8 @@ In Slack, invite the bot to any channel where you want it to listen:
    - **Allowed User IDs** (optional): Comma-separated list of Slack user IDs that are allowed to interact with the bot. Leave empty to allow all users.
 4. Click **Save Settings**
 5. Click **Test Connection** to verify
+
+> **Note:** After saving, you'll need to **restart your Open Assistant instance** for the Slack integration to start working.
 
 ## Configuration Options
 


### PR DESCRIPTION
## Summary
Updated the Slack integration documentation to clarify that an Open Assistant instance restart is required after saving the Slack integration settings for the integration to become active.

## Changes
- Added a note after the "Test Connection" step in the Socket Mode setup section (after line 114) indicating that users must restart their Open Assistant instance for the Slack integration to start working
- Added the same note after the "Test Connection" step in the HTTP Webhooks setup section (after line 192) for consistency across both setup methods

## Details
This documentation update addresses a potential point of confusion for users who may save their Slack integration settings and expect the bot to immediately start functioning. The added notes clearly communicate that a restart is a necessary step in the setup process, which should reduce support questions and improve the user experience during initial configuration.

https://claude.ai/code/session_01CKR9Ai8WQ8QVYQq1SczT9g