### PR TITLE
Add WhatsApp connection test endpoint and improve QR linking flow

### DIFF
--- a/src/api/whatsapp.py
+++ b/src/api/whatsapp.py
@@ -65,6 +65,14 @@ async def send_message(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/test-connection")
+async def test_connection(
+    whatsapp_service: WhatsAppService = Depends(get_whatsapp_service),
+) -> Dict[str, Any]:
+    """Test WhatsApp bridge connectivity and authentication status."""
+    return whatsapp_service.test_connection()
+
+
 @router.post("/webhook/configure")
 async def configure_webhook(
     request: WebhookConfigRequest, whatsapp_service: WhatsAppService = Depends(get_whatsapp_service)

--- a/src/ui/static/js/settings.js
+++ b/src/ui/static/js/settings.js
@@ -1395,7 +1395,11 @@ async function pollWhatsAppQr() {
             statusText.textContent = 'WhatsApp is linked and ready.';
             toast.success('WhatsApp is connected!');
             stopWhatsAppQrPolling();
-            setTimeout(closeWhatsAppQrModal, 2000);
+            await toggleIntegration('whatsapp', true);
+            setTimeout(async () => {
+                closeWhatsAppQrModal();
+                await loadIntegrations();
+            }, 2000);
             return;
         }
 


### PR DESCRIPTION
## Summary
This PR enhances the WhatsApp integration by adding a dedicated connection test endpoint and improving the user experience when linking WhatsApp accounts via QR code.

## Key Changes
- **New API endpoint**: Added `POST /test-connection` to the WhatsApp router that tests bridge connectivity and authentication status
- **Improved QR linking flow**: Enhanced the WhatsApp QR polling logic to automatically update integration status and refresh the UI after successful connection
  - Now calls `toggleIntegration('whatsapp', true)` to enable the integration
  - Reloads integrations list after the modal closes to reflect the updated state

## Implementation Details
- The new test connection endpoint delegates to `WhatsAppService.test_connection()` for the actual connectivity check
- The QR polling improvements ensure that after a successful WhatsApp link, the UI is properly synchronized with the backend state without requiring a manual page refresh
- The integration toggle and reload are performed asynchronously within the 2-second delay before closing the modal, providing a seamless user experience