### PR TITLE
Fix coordinator notify_owner awareness when only Slack (or only WhatsApp) is enabled

### DIFF
--- a/src/core/migrations/056_coordinator_slack_notify_awareness.sql
+++ b/src/core/migrations/056_coordinator_slack_notify_awareness.sql
@@ -1,0 +1,50 @@
+-- Fix coordinator/communication skill awareness of Slack notifications.
+--
+-- Problems addressed:
+--   1. "slack" was absent from the communication skill's intent_keywords, so a
+--      message like "Slack me when done" might not select the skill.
+--   2. The backstory told the LLM that the notify_owner default channel is
+--      WhatsApp, which is wrong when only Slack is configured.
+
+UPDATE agent_definitions
+SET
+    intent_keywords = '["gmail", "outlook", "whatsapp", "slack", "mail", "text", "send", "notify", "message me"]',
+    backstory = 'You are a communication specialist who excels at drafting clear, professional messages and managing email workflows.
+
+CRITICAL: You MUST use your tools to perform actions. NEVER just describe what you would do — actually DO it.
+
+SENDING:
+- Send email: USE google_send_email or outlook_send_email
+- Create draft: USE google_create_draft or outlook_create_draft
+- Reply to email: USE google_reply_email (requires message_id and thread_id)
+- Send WhatsApp to a specific number: USE whatsapp_send_message
+- Notify the owner/user (WhatsApp or Slack): USE notify_owner
+  - The channel parameter selects the delivery service (''whatsapp'' or ''slack'').
+  - If you do not specify a channel, the tool picks whichever service is currently enabled automatically.
+  - Use this when the user says "send me a message", "notify me", "let me know", "WhatsApp me", "Slack me", or when you need to proactively reach the owner (e.g. scheduled task results, reminders, alerts).
+  - The tool will inform you if the chosen channel is not enabled or not configured.
+
+EMAIL MANAGEMENT & CLASSIFICATION:
+Gmail:
+- Read emails: USE google_read_emails, google_search_emails, or google_get_email
+- Read attachments: USE google_get_attachment (extracts text from PDF, DOCX, text files)
+- Get labels: USE google_get_labels to discover available labels
+- Classify/label: USE google_modify_labels to apply labels, mark read/unread, star, archive
+- Delete: USE google_trash_email
+
+Outlook:
+- Read emails: USE outlook_read_emails, outlook_search_emails, or outlook_get_email
+- Read attachments: USE outlook_get_attachment (extracts text from PDF, DOCX, text files)
+
+EMAIL CLASSIFICATION WORKFLOW:
+When asked to classify and label emails (e.g. via a cron job):
+1. USE google_read_emails/outlook_read_emails to fetch recent unread emails
+2. Analyze each email''s subject, sender, and content
+3. USE google_get_labels to see available labels (Gmail only)
+4. USE google_modify_labels on each email to apply the appropriate label(s) (Gmail only)
+5. Optionally mark as read by removing the UNREAD label
+
+Always confirm with the user before sending external communications unless explicitly told to proceed.'
+WHERE name = 'communication';
+
+INSERT OR IGNORE INTO schema_migrations (version) VALUES ('056_coordinator_slack_notify_awareness');

--- a/src/core/migrations/056_coordinator_slack_notify_awareness.sql
+++ b/src/core/migrations/056_coordinator_slack_notify_awareness.sql
@@ -20,7 +20,7 @@ SENDING:
 - Send WhatsApp to a specific number: USE whatsapp_send_message
 - Notify the owner/user (WhatsApp or Slack): USE notify_owner
   - The channel parameter selects the delivery service (''whatsapp'' or ''slack'').
-  - If you do not specify a channel, the tool picks whichever service is currently enabled automatically.
+  - If you do not specify a channel, WhatsApp is used when enabled; Slack is used as a fallback when only Slack is configured.
   - Use this when the user says "send me a message", "notify me", "let me know", "WhatsApp me", "Slack me", or when you need to proactively reach the owner (e.g. scheduled task results, reminders, alerts).
   - The tool will inform you if the chosen channel is not enabled or not configured.
 

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -1654,7 +1654,7 @@ def define_whatsapp_tools():
                     "(e.g., 'send me a message', 'message me', 'notify me', 'WhatsApp me', 'Slack me'), "
                     "(2) You need to proactively notify the owner (e.g., scheduled task results, reminders, alerts). "
                     "The 'channel' parameter selects the delivery channel ('whatsapp' or 'slack'). "
-                    "If omitted, the channel is chosen automatically based on which service is enabled. "
+                    "If omitted, WhatsApp is used when enabled; Slack is used as a fallback when only Slack is enabled. "
                     "The phone number (WhatsApp) and default channel ID (Slack) are resolved automatically from settings. "
                     "The tool will inform you if the chosen channel is not enabled or not fully configured."
                 ),

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -1653,14 +1653,15 @@ def define_whatsapp_tools():
                     "Use this when: (1) The user asks you to send them a message or notification "
                     "(e.g., 'send me a message', 'message me', 'notify me', 'WhatsApp me', 'Slack me'), "
                     "(2) You need to proactively notify the owner (e.g., scheduled task results, reminders, alerts). "
-                    "The 'channel' parameter selects the delivery channel — defaults to 'whatsapp'; use 'slack' to send via Slack instead. "
+                    "The 'channel' parameter selects the delivery channel ('whatsapp' or 'slack'). "
+                    "If omitted, the channel is chosen automatically based on which service is enabled. "
                     "The phone number (WhatsApp) and default channel ID (Slack) are resolved automatically from settings. "
                     "The tool will inform you if the chosen channel is not enabled or not fully configured."
                 ),
                 parameters_model=NotifyOwnerRequest,
             ),
             executor=None,
-            service_name="whatsapp",
+            service_name="messaging",
         )
     )
 

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -944,9 +944,7 @@ class ToolExecutor:
             wa_on = whatsapp_service and _is_enabled(
                 whatsapp_service.settings_repo.get("whatsapp.enabled")
             )
-            sl_on = slack_service and _is_enabled(
-                slack_service.settings_repo.get("slack.enabled")
-            )
+            sl_on = slack_service and _is_enabled(slack_service.settings_repo.get("slack.enabled"))
             if wa_on:
                 channel = "whatsapp"
             elif sl_on:

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -7,6 +7,7 @@ from src.core.tools.registry import get_tool_registry
 from src.models.nextcloud import UploadFileRequest as NextcloudUploadFileRequest
 from src.models.outlook import UploadFileRequest as OutlookUploadFileRequest
 from src.utils.logger import get_logger
+from src.utils.settings import settings_truthy
 
 logger = get_logger(__name__)
 
@@ -181,7 +182,11 @@ class ToolExecutor:
                 return error_result
 
         service = self.services.get(tool.service_name)
-        if not service:
+        # "messaging" (notify_owner) is a pseudo-service gated on either WhatsApp
+        # or Slack in the registry; it has no service instance because
+        # _handle_notify_owner resolves the whatsapp/slack services itself. Let it
+        # fall through to _route_tool_call instead of short-circuiting.
+        if not service and tool.service_name != "messaging":
             error_result = {
                 "success": False,
                 "error": f"Service not available: {tool.service_name}",
@@ -932,19 +937,14 @@ class ToolExecutor:
         whatsapp_service = self.services.get("whatsapp")
         slack_service = self.services.get("slack")
 
-        def _is_enabled(val) -> bool:
-            if val is None:
-                return False
-            if isinstance(val, bool):
-                return val
-            return str(val).lower() == "true"
-
         if channel is None:
             # Auto-detect: prefer whatsapp if enabled, otherwise fall back to slack
-            wa_on = whatsapp_service and _is_enabled(
+            wa_on = whatsapp_service and settings_truthy(
                 whatsapp_service.settings_repo.get("whatsapp.enabled")
             )
-            sl_on = slack_service and _is_enabled(slack_service.settings_repo.get("slack.enabled"))
+            sl_on = slack_service and settings_truthy(
+                slack_service.settings_repo.get("slack.enabled")
+            )
             if wa_on:
                 channel = "whatsapp"
             elif sl_on:

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -927,10 +927,35 @@ class ToolExecutor:
         attempting delivery, and returns an informative error if not.
         """
         message = arguments.get("message", "")
-        channel = arguments.get("channel", "whatsapp")
+        channel = arguments.get("channel")
 
         whatsapp_service = self.services.get("whatsapp")
         slack_service = self.services.get("slack")
+
+        def _is_enabled(val) -> bool:
+            if val is None:
+                return False
+            if isinstance(val, bool):
+                return val
+            return str(val).lower() == "true"
+
+        if channel is None:
+            # Auto-detect: prefer whatsapp if enabled, otherwise fall back to slack
+            wa_on = whatsapp_service and _is_enabled(
+                whatsapp_service.settings_repo.get("whatsapp.enabled")
+            )
+            sl_on = slack_service and _is_enabled(
+                slack_service.settings_repo.get("slack.enabled")
+            )
+            if wa_on:
+                channel = "whatsapp"
+            elif sl_on:
+                channel = "slack"
+            else:
+                return {
+                    "success": False,
+                    "error": "Neither WhatsApp nor Slack is enabled. Enable one in settings.",
+                }
 
         if channel == "whatsapp":
             if not whatsapp_service:

--- a/src/core/tools/registry.py
+++ b/src/core/tools/registry.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from src.core.repositories.settings import SettingsRepository
 from src.core.tools.schema import ToolSchema
+from src.utils.settings import settings_truthy
 
 
 class Tool:
@@ -96,13 +97,6 @@ class ToolRegistry:
             "yahoo_finance": "yahoo_finance.enabled",
         }
 
-        def _setting_truthy(val) -> bool:
-            if val is None:
-                return False
-            if isinstance(val, bool):
-                return val
-            return str(val).lower() == "true"
-
         # Check which integrations are enabled
         enabled_tools = []
         for tool in self._tools.values():
@@ -114,8 +108,8 @@ class ToolRegistry:
             # "messaging" tools (notify_owner) are available when either
             # WhatsApp or Slack is enabled — not gated on a single service.
             if tool.service_name == "messaging":
-                wa = _setting_truthy(settings_repo.get("whatsapp.enabled"))
-                sl = _setting_truthy(settings_repo.get("slack.enabled"))
+                wa = settings_truthy(settings_repo.get("whatsapp.enabled"))
+                sl = settings_truthy(settings_repo.get("slack.enabled"))
                 if wa or sl:
                     enabled_tools.append(tool.schema)
                 continue
@@ -133,7 +127,7 @@ class ToolRegistry:
             # Check if integration is enabled
             service_enabled = settings_repo.get(setting_key)
             # Handle both bool and string storage: "false" as string is truthy in Python
-            if not _setting_truthy(service_enabled):
+            if not settings_truthy(service_enabled):
                 continue
 
             # Service is enabled — all its tools are available.

--- a/src/core/tools/registry.py
+++ b/src/core/tools/registry.py
@@ -96,12 +96,28 @@ class ToolRegistry:
             "yahoo_finance": "yahoo_finance.enabled",
         }
 
+        def _setting_truthy(val) -> bool:
+            if val is None:
+                return False
+            if isinstance(val, bool):
+                return val
+            return str(val).lower() == "true"
+
         # Check which integrations are enabled
         enabled_tools = []
         for tool in self._tools.values():
             # System and search tools are always available
             if tool.service_name in ("system", "search"):
                 enabled_tools.append(tool.schema)
+                continue
+
+            # "messaging" tools (notify_owner) are available when either
+            # WhatsApp or Slack is enabled — not gated on a single service.
+            if tool.service_name == "messaging":
+                wa = _setting_truthy(settings_repo.get("whatsapp.enabled"))
+                sl = _setting_truthy(settings_repo.get("slack.enabled"))
+                if wa or sl:
+                    enabled_tools.append(tool.schema)
                 continue
 
             # Plugin tools: check plugin.{id}.enabled
@@ -117,11 +133,7 @@ class ToolRegistry:
             # Check if integration is enabled
             service_enabled = settings_repo.get(setting_key)
             # Handle both bool and string storage: "false" as string is truthy in Python
-            if service_enabled is None:
-                continue
-            if isinstance(service_enabled, bool) and not service_enabled:
-                continue
-            if isinstance(service_enabled, str) and service_enabled.lower() != "true":
+            if not _setting_truthy(service_enabled):
                 continue
 
             # Service is enabled — all its tools are available.

--- a/src/services/plugin_service.py
+++ b/src/services/plugin_service.py
@@ -14,6 +14,7 @@ from src.core.repositories.credentials import CredentialsRepository
 from src.core.repositories.settings import SettingsRepository
 from src.core.tools.registry import Tool, get_tool_registry
 from src.core.tools.schema import ToolSchema
+from src.utils.settings import settings_truthy
 from src.models.plugin import (
     PluginAuth,
     PluginCredentialsRequest,
@@ -477,12 +478,7 @@ class PluginService(BaseService):
     def _is_plugin_enabled(self, plugin_id: str) -> bool:
         """Check if a plugin is enabled, handling both bool and string storage."""
         value = self.settings_repo.get(f"plugin.{plugin_id}.enabled")
-        if value is None:
-            return False
-        if isinstance(value, bool):
-            return value
-        # Backwards compat: value stored as string before the fix
-        return str(value).lower() == "true"
+        return settings_truthy(value)
 
     # ------------------------------------------------------------------
     # Config helpers

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -1,0 +1,17 @@
+"""Helpers for interpreting settings values."""
+
+from typing import Any
+
+
+def settings_truthy(val: Any) -> bool:
+    """Return whether a settings value should be treated as enabled/truthy.
+
+    Settings may be stored as a real bool (``value_type='bool'`` rows) or, for
+    legacy rows written before typed storage, as the strings ``'true'``/``'false'``.
+    ``None`` and any other value are treated as disabled.
+    """
+    if val is None:
+        return False
+    if isinstance(val, bool):
+        return val
+    return str(val).lower() == "true"

--- a/tests/test_notify_owner.py
+++ b/tests/test_notify_owner.py
@@ -1,0 +1,288 @@
+"""Tests for the notify_owner tool.
+
+Covers:
+- Channel auto-detection (WhatsApp preferred, Slack fallback, neither-enabled error)
+- Explicit channel selection and its error paths
+- The execute_tool dispatch path (regression: must route to the handler, not
+  short-circuit with "Service not available: messaging")
+- Registry gating: notify_owner is enabled when either WhatsApp or Slack is on
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.tools.executor import ToolExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _settings_repo(values):
+    """Fake settings repo whose ``.get(key)`` returns ``values.get(key)``."""
+
+    repo = MagicMock()
+    repo.get.side_effect = lambda k: values.get(k)
+    return repo
+
+
+def _service(values, send_return=None):
+    """A fake whatsapp/slack service carrying a settings repo."""
+
+    svc = MagicMock()
+    svc.settings_repo = _settings_repo(values)
+    if send_return is not None:
+        svc.send_message_to_owner.return_value = send_return
+        svc.send_message_to_default_channel.return_value = send_return
+    return svc
+
+
+@pytest.fixture
+def executor():
+    """A ToolExecutor backed by a freshly-initialized tool registry.
+
+    Swaps the module-global registry so the test is isolated from other tests
+    and from global init state, and restores it afterwards.
+    """
+    import src.core.tools.definitions as definitions
+    import src.core.tools.registry as reg_module
+
+    registry = reg_module.ToolRegistry()
+    original = reg_module._registry
+    reg_module._registry = registry
+    try:
+        definitions.initialize_all_tools()
+        yield ToolExecutor()
+    finally:
+        reg_module._registry = original
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection (channel omitted)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOwnerAutoDetect:
+    def test_prefers_whatsapp_when_both_enabled(self, executor):
+        wa = _service(
+            {"whatsapp.enabled": True, "whatsapp.phone_number": "+1"},
+            send_return={"success": True, "via": "whatsapp"},
+        )
+        sl = _service({"slack.enabled": True, "slack.default_channel": "C"})
+        executor.services["whatsapp"] = wa
+        executor.services["slack"] = sl
+
+        result = executor._handle_notify_owner({"message": "hi"})
+
+        assert result == {"success": True, "via": "whatsapp"}
+        wa.send_message_to_owner.assert_called_once_with(message="hi")
+        sl.send_message_to_default_channel.assert_not_called()
+
+    def test_falls_back_to_slack_when_only_slack_enabled(self, executor):
+        wa = _service({"whatsapp.enabled": False, "whatsapp.phone_number": "+1"})
+        sl = _service(
+            {"slack.enabled": True, "slack.default_channel": "C"},
+            send_return={"success": True, "via": "slack"},
+        )
+        executor.services["whatsapp"] = wa
+        executor.services["slack"] = sl
+
+        result = executor._handle_notify_owner({"message": "hi"})
+
+        assert result == {"success": True, "via": "slack"}
+        sl.send_message_to_default_channel.assert_called_once_with(message="hi")
+        wa.send_message_to_owner.assert_not_called()
+
+    def test_falls_back_to_slack_when_whatsapp_service_absent(self, executor):
+        sl = _service(
+            {"slack.enabled": True, "slack.default_channel": "C"},
+            send_return={"success": True},
+        )
+        executor.services["slack"] = sl
+        # No whatsapp service registered at all.
+
+        result = executor._handle_notify_owner({"message": "hi"})
+
+        assert result["success"] is True
+        sl.send_message_to_default_channel.assert_called_once_with(message="hi")
+
+    def test_neither_enabled_returns_error(self, executor):
+        executor.services["whatsapp"] = _service({"whatsapp.enabled": False})
+        executor.services["slack"] = _service({"slack.enabled": False})
+
+        result = executor._handle_notify_owner({"message": "hi"})
+
+        assert result["success"] is False
+        assert "Neither WhatsApp nor Slack is enabled" in result["error"]
+
+    def test_neither_service_present_returns_error(self, executor):
+        # No services registered at all.
+        result = executor._handle_notify_owner({"message": "hi"})
+
+        assert result["success"] is False
+        assert "Neither WhatsApp nor Slack is enabled" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Explicit channel selection
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOwnerExplicitChannel:
+    def test_explicit_whatsapp_sends(self, executor):
+        wa = _service(
+            {"whatsapp.enabled": True, "whatsapp.phone_number": "+1"},
+            send_return={"success": True},
+        )
+        executor.services["whatsapp"] = wa
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "whatsapp"})
+
+        assert result["success"] is True
+        wa.send_message_to_owner.assert_called_once_with(message="hi")
+
+    def test_explicit_whatsapp_disabled_returns_error(self, executor):
+        wa = _service({"whatsapp.enabled": False, "whatsapp.phone_number": "+1"})
+        executor.services["whatsapp"] = wa
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "whatsapp"})
+
+        assert result["success"] is False
+        assert "not enabled" in result["error"]
+
+    def test_explicit_whatsapp_missing_phone_returns_error(self, executor):
+        wa = _service({"whatsapp.enabled": True})  # no phone_number configured
+        executor.services["whatsapp"] = wa
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "whatsapp"})
+
+        assert result["success"] is False
+        assert "phone number" in result["error"].lower()
+
+    def test_explicit_whatsapp_service_absent_returns_error(self, executor):
+        result = executor._handle_notify_owner({"message": "hi", "channel": "whatsapp"})
+
+        assert result["success"] is False
+        assert "not available" in result["error"].lower()
+
+    def test_explicit_slack_sends(self, executor):
+        sl = _service(
+            {"slack.enabled": True, "slack.default_channel": "C"},
+            send_return={"success": True},
+        )
+        executor.services["slack"] = sl
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "slack"})
+
+        assert result["success"] is True
+        sl.send_message_to_default_channel.assert_called_once_with(message="hi")
+
+    def test_explicit_slack_disabled_returns_error(self, executor):
+        sl = _service({"slack.enabled": False, "slack.default_channel": "C"})
+        executor.services["slack"] = sl
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "slack"})
+
+        assert result["success"] is False
+        assert "not enabled" in result["error"]
+
+    def test_explicit_slack_missing_channel_returns_error(self, executor):
+        sl = _service({"slack.enabled": True})  # no default_channel configured
+        executor.services["slack"] = sl
+
+        result = executor._handle_notify_owner({"message": "hi", "channel": "slack"})
+
+        assert result["success"] is False
+        assert "Default Slack channel" in result["error"]
+
+    def test_explicit_slack_service_absent_returns_error(self, executor):
+        result = executor._handle_notify_owner({"message": "hi", "channel": "slack"})
+
+        assert result["success"] is False
+        assert "not available" in result["error"].lower()
+
+    def test_unknown_channel_returns_error(self, executor):
+        result = executor._handle_notify_owner({"message": "hi", "channel": "carrier_pigeon"})
+
+        assert result["success"] is False
+        assert "Unknown channel" in result["error"]
+        assert "carrier_pigeon" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# execute_tool dispatch path (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOwnerExecuteToolDispatch:
+    """Regression: execute_tool must route notify_owner to _handle_notify_owner.
+
+    Previously, notify_owner's service_name="messaging" had no entry in
+    ToolExecutor.services, so execute_tool short-circuited with
+    "Service not available: messaging" before the handler was ever reached.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_routes_to_handler_slack_only(self, executor):
+        sl = _service(
+            {"slack.enabled": True, "slack.default_channel": "C"},
+            send_return={"success": True, "message_id": "m1"},
+        )
+        executor.services["slack"] = sl
+
+        result = await executor.execute_tool("notify_owner", {"message": "hi"})
+
+        # The regression returned a top-level "Service not available" error.
+        assert result.get("error") != "Service not available: messaging"
+        assert "error" not in result
+        assert result["success"] is True
+        sl.send_message_to_default_channel.assert_called_once_with(message="hi")
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_neither_enabled_returns_handler_error(self, executor):
+        executor.services["whatsapp"] = _service({"whatsapp.enabled": False})
+        executor.services["slack"] = _service({"slack.enabled": False})
+
+        result = await executor.execute_tool("notify_owner", {"message": "hi"})
+
+        # Handler returns its own failure dict; execute_tool wraps it as a result.
+        assert result["success"] is True
+        assert result["result"]["success"] is False
+        assert "Neither WhatsApp nor Slack is enabled" in result["result"]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Registry gating
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOwnerRegistryGating:
+    """notify_owner uses the "messaging" pseudo-service and must be included in
+    enabled tools when either WhatsApp or Slack is enabled."""
+
+    @staticmethod
+    def _enabled_names(executor, settings_values):
+        names = {
+            t.name
+            for t in executor.registry.list_tools(
+                _settings_repo(settings_values), enabled_only=True
+            )
+        }
+        return names
+
+    def test_present_when_only_slack_enabled(self, executor):
+        names = self._enabled_names(executor, {"slack.enabled": True, "whatsapp.enabled": False})
+        assert "notify_owner" in names
+
+    def test_present_when_only_whatsapp_enabled(self, executor):
+        names = self._enabled_names(executor, {"slack.enabled": False, "whatsapp.enabled": True})
+        assert "notify_owner" in names
+
+    def test_present_when_both_enabled(self, executor):
+        names = self._enabled_names(executor, {"slack.enabled": True, "whatsapp.enabled": True})
+        assert "notify_owner" in names
+
+    def test_absent_when_neither_enabled(self, executor):
+        names = self._enabled_names(executor, {"slack.enabled": False, "whatsapp.enabled": False})
+        assert "notify_owner" not in names


### PR DESCRIPTION
- notify_owner was gated on whatsapp.enabled so it never appeared in the LLM
  tool manifest when only Slack was configured. Changed service_name to the new
  "messaging" pseudo-service so the registry enables it when either
  whatsapp.enabled or slack.enabled is true.
- executor auto-detects the delivery channel when none is specified (prefers
  WhatsApp if enabled, falls back to Slack), instead of hardcoding "whatsapp".
- communication skill intent_keywords now include "slack" and "notify" so the
  skill is reliably selected when the user or a cron job mentions Slack.
- Communication skill backstory updated to reflect automatic channel selection
  rather than saying the default is always WhatsApp.
- Registry truthy-check consolidated into a shared _setting_truthy helper.