### PR TITLE
Add mobile responsive design for artifacts and agent cards

### DIFF
--- a/src/ui/static/artifacts.html
+++ b/src/ui/static/artifacts.html
@@ -162,6 +162,85 @@
             font-size: 0.95rem;
         }
         .artifact-input:focus { outline: none; border-color: var(--primary-color); }
+
+        /* ================================================================
+           RESPONSIVE / MOBILE
+           ================================================================ */
+        @media (max-width: 768px) {
+            .artifacts-container {
+                padding: 16px;
+                border-radius: 0;
+            }
+
+            .artifacts-header {
+                flex-wrap: wrap;
+                gap: 12px;
+            }
+
+            .artifacts-header h1 {
+                font-size: 1.4rem;
+            }
+
+            /* Card-stacking table pattern */
+            .jobs-table,
+            .jobs-table thead,
+            .jobs-table tbody,
+            .jobs-table tr,
+            .jobs-table td {
+                display: block;
+                width: 100%;
+                box-sizing: border-box;
+            }
+
+            .jobs-table thead {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+                clip: rect(0 0 0 0);
+                white-space: nowrap;
+            }
+
+            .jobs-table tr {
+                border: 1px solid var(--border-color);
+                border-radius: 10px;
+                margin-bottom: 12px;
+                padding: 6px 12px;
+                background: var(--background-color);
+            }
+
+            .jobs-table tr:hover { background: var(--background-color); }
+
+            .jobs-table td {
+                padding: 8px 0;
+                border-bottom: 1px solid var(--border-color);
+                display: flex;
+                justify-content: space-between;
+                align-items: flex-start;
+                gap: 12px;
+                text-align: right;
+            }
+
+            .jobs-table td:last-child { border-bottom: none; }
+
+            .jobs-table td[data-label]::before {
+                content: attr(data-label);
+                font-weight: 600;
+                color: var(--text-muted);
+                text-align: left;
+                flex-shrink: 0;
+                white-space: nowrap;
+            }
+
+            .job-actions {
+                flex-wrap: wrap;
+                justify-content: flex-end;
+            }
+
+            .job-action-btn {
+                min-height: 36px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -258,17 +337,17 @@
                 const secretLabel = a.has_secret ? 'Passphrase' : 'Set passphrase';
                 return `
                     <tr>
-                        <td>
+                        <td data-label="Name">
                             <div class="artifact-name">${escapeHtml(name)}</div>
                             ${a.title ? `<div class="artifact-file">${escapeHtml(a.filename)}</div>` : ''}
                         </td>
-                        <td>${escapeHtml(shortType(a.mime_type))}</td>
-                        <td>${formatSize(a.size)}</td>
-                        <td>
+                        <td data-label="Type">${escapeHtml(shortType(a.mime_type))}</td>
+                        <td data-label="Size">${formatSize(a.size)}</td>
+                        <td data-label="Visibility">
                             <span class="status-badge-inline ${visClass}">${visLabel}</span>${lock}
                         </td>
-                        <td>${a.created_at ? formatDateTime(a.created_at) : '—'}</td>
-                        <td>
+                        <td data-label="Created">${a.created_at ? formatDateTime(a.created_at) : '—'}</td>
+                        <td data-label="Actions">
                             <div class="job-actions">
                                 <button class="job-action-btn" onclick="viewArtifact('${a.artifact_id}')">View</button>
                                 <button class="job-action-btn btn-neutral" onclick="copyLink('${a.artifact_id}')">${linkLabel}</button>

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -1866,6 +1866,36 @@ body {
     cursor: not-allowed;
 }
 
+/* Agent cards — mobile responsive */
+@media (max-width: 768px) {
+    .agent-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .agent-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .agent-footer {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .agent-footer .btn {
+        flex: 1;
+        min-width: 0;
+        text-align: center;
+    }
+
+    .section-title-row > .btn {
+        align-self: stretch;
+        text-align: center;
+    }
+}
+
 /* Tools Tab - Drag & Drop Zones */
 .tool-drop-zone {
     background: var(--color-surface);


### PR DESCRIPTION
## Summary
This PR adds comprehensive mobile responsive styling to improve the user experience on smaller screens. The changes focus on making the artifacts table and agent cards adapt gracefully to mobile viewports (≤768px).

## Key Changes

**Artifacts Page (`src/ui/static/artifacts.html`)**
- Added mobile-first media query for screens ≤768px
- Implemented card-stacking table pattern that converts table rows into individual cards on mobile
- Hides table headers using accessible clip technique and displays column labels via `data-label` attributes
- Adjusted container padding, border-radius, and header layout for mobile
- Reduced heading size (h1: 1.4rem) and adjusted gaps for better mobile spacing
- Added `data-label` attributes to all table cells for mobile column identification
- Ensured action buttons remain accessible and properly wrapped on mobile

**Common Styles (`src/ui/static/css/common.css`)**
- Added mobile responsive styles for agent cards
- Changed agent header to flex-column layout on mobile
- Made agent actions full-width with space-between distribution
- Added flex-wrap to agent footer with responsive button sizing
- Ensured section title buttons stretch and center-align on mobile

## Implementation Details
- Uses CSS `display: block` to convert table structure to card layout on mobile
- Leverages CSS `attr()` function with `data-label` to display column headers without duplicating HTML
- Maintains accessibility by hiding headers with `clip: rect()` rather than `display: none`
- Preserves visual hierarchy and spacing consistency across responsive breakpoints