### PR TITLE
Add Google Docs/Sheets/Slides editing tools for updating existing files

### DIFF
--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -10,9 +10,9 @@ Open Assistant integrates with Google's platform through the Google Cloud Consol
 - Gmail (email reading, draft creation, sending, label management)
 - Google Calendar (event management)
 - Google Drive (file listing, searching, reading, uploading, organizing)
-- Google Docs (create, read, append, update documents)
-- Google Sheets (create, read, write, append to spreadsheets)
-- Google Slides (create presentations, read slide content)
+- Google Docs (create, read, append, update, find-and-replace documents)
+- Google Sheets (create, read, write, append, clear spreadsheets)
+- Google Slides (create presentations, read content, add slides, find-and-replace, insert text)
 
 ## Prerequisites
 
@@ -404,7 +404,15 @@ google_docs_client.docs_append(
     content="\n\n## New Section\nContent to add at the end."
 )
 
-# Replace all content
+# Find and replace specific text (preferred for edits — keeps the rest of the doc intact)
+google_docs_client.docs_replace_text(
+    document_id="<document_id>",
+    find="Q3",
+    replace="Q4",
+)
+# Returns: {"document_id": "...", "status": "replaced", "occurrences_changed": N, "url": "..."}
+
+# Replace ALL content (destructive — only for a deliberate full rewrite)
 google_docs_client.docs_update(
     document_id="<document_id>",
     content="Completely new document content."
@@ -461,6 +469,12 @@ google_sheets_client.sheets_append(
     range_notation="Sheet1!A1",
     values=[["Charlie", 35, "Berlin"]]
 )
+
+# Clear a range's values (formatting is kept)
+google_sheets_client.sheets_clear(
+    spreadsheet_id="<id>",
+    range_notation="Sheet1!A2:C100"
+)
 ```
 
 ## Google Slides Operations
@@ -476,7 +490,36 @@ pres = google_slides_client.slides_create(title="Q4 Review")
 
 ```python
 pres = google_slides_client.slides_get(presentation_id="<id>")
-# Returns: {"title": "...", "slides_count": N, "slides": [{"slide_number": 1, "text": "..."}, ...]}
+# Returns: {"title": "...", "slides_count": N,
+#           "slides": [{"slide_number": 1, "slide_id": "...", "text": "...", "speaker_notes": "..."}, ...]}
+```
+
+### Edit a Presentation
+
+```python
+# Add a new slide with title and body text
+google_slides_client.slides_add_slide(
+    presentation_id="<id>",
+    title="Revenue",
+    body="Up 12% quarter-over-quarter.",
+    layout="TITLE_AND_BODY",  # or TITLE_ONLY, SECTION_HEADER, BLANK
+)
+# Returns: {"presentation_id": "...", "slide_id": "...", "status": "created", "url": "..."}
+
+# Find and replace text across all slides (preferred for wording updates)
+google_slides_client.slides_replace_text(
+    presentation_id="<id>",
+    find="DRAFT",
+    replace="FINAL",
+)
+# Returns: {"presentation_id": "...", "status": "replaced", "occurrences_changed": N, "url": "..."}
+
+# Insert a text box onto a specific slide (slide_id comes from slides_get)
+google_slides_client.slides_insert_text(
+    presentation_id="<id>",
+    slide_id="<slide_id>",
+    text="Footnote: figures are unaudited.",
+)
 ```
 
 ## Token Management

--- a/src/core/migrations/057_google_docs_slides_edit_tools.sql
+++ b/src/core/migrations/057_google_docs_slides_edit_tools.sql
@@ -1,0 +1,78 @@
+-- Migration: 057_google_docs_slides_edit_tools
+-- Adds targeted editing tools for Google Docs, Sheets, and Slides so agents can
+-- UPDATE existing files instead of only creating/appending/full-replacing them.
+-- New tools (all within already-granted documents/spreadsheets/presentations scopes):
+--   google_docs_replace_text   - find & replace in a Doc (non-destructive)
+--   google_sheets_clear        - clear a range's values
+--   google_slides_add_slide    - add a slide with optional title/body
+--   google_slides_replace_text - find & replace across a presentation
+--   google_slides_insert_text  - insert a text box onto a slide
+--
+-- Only the write-capable agents (writer, file_handler) receive these; the
+-- research agent stays read-only. Each UPDATE anchors on a sibling tool token
+-- guaranteed present from migration 044 and is guarded by NOT LIKE for idempotency.
+
+-- ============================================================================
+-- Google Docs: add find-and-replace next to google_docs_update
+-- ============================================================================
+UPDATE agent_definitions
+SET
+    tools = json(
+        replace(
+            json_extract(tools, '$'),
+            '"google_docs_update"',
+            '"google_docs_update","google_docs_replace_text"'
+        )
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE name IN ('writer', 'file_handler')
+  AND tools LIKE '%google_docs_update%'
+  AND tools NOT LIKE '%google_docs_replace_text%';
+
+-- ============================================================================
+-- Google Sheets: add clear next to google_sheets_append
+-- ============================================================================
+UPDATE agent_definitions
+SET
+    tools = json(
+        replace(
+            json_extract(tools, '$'),
+            '"google_sheets_append"',
+            '"google_sheets_append","google_sheets_clear"'
+        )
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE name IN ('writer', 'file_handler')
+  AND tools LIKE '%google_sheets_append%'
+  AND tools NOT LIKE '%google_sheets_clear%';
+
+-- ============================================================================
+-- Google Slides: add editing tools next to google_slides_get
+-- ============================================================================
+UPDATE agent_definitions
+SET
+    tools = json(
+        replace(
+            json_extract(tools, '$'),
+            '"google_slides_get"',
+            '"google_slides_get","google_slides_add_slide","google_slides_replace_text","google_slides_insert_text"'
+        )
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE name IN ('writer', 'file_handler')
+  AND tools LIKE '%google_slides_get%'
+  AND tools NOT LIKE '%google_slides_add_slide%';
+
+-- ============================================================================
+-- Refresh file_handler goal to advertise the richer edit capability.
+-- ============================================================================
+UPDATE agent_definitions
+SET
+    goal = 'Manage files across Nextcloud, OneDrive, and Google Drive — list, search, read, upload, download, move, copy, and delete files (Google Drive is read-only). Create and edit Google Docs, Google Sheets, and Google Slides, including targeted find-and-replace edits and adding slides.',
+    updated_at = CURRENT_TIMESTAMP
+WHERE name = 'file_handler';
+
+-- ============================================================================
+-- Record migration as applied
+-- ============================================================================
+INSERT OR IGNORE INTO schema_migrations (version) VALUES ('057_google_docs_slides_edit_tools');

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -43,6 +43,7 @@ from src.models.google import (
     DocsAppendRequest,
     DocsCreateRequest,
     DocsGetRequest,
+    DocsReplaceTextRequest,
     DocsUpdateRequest,
     DriveGetFileRequest,
     DriveListFilesRequest,
@@ -66,12 +67,16 @@ from src.models.google import (
     SearchPlacesRequest,
     SendEmailRequest,
     SheetsAppendRequest,
+    SheetsClearRequest,
     SheetsCreateRequest,
     SheetsGetRequest,
     SheetsReadRequest,
     SheetsWriteRequest,
+    SlidesAddSlideRequest,
     SlidesCreateRequest,
     SlidesGetRequest,
+    SlidesInsertTextRequest,
+    SlidesReplaceTextRequest,
     TrashEmailRequest,
     UpdateCalendarEventRequest,
 )
@@ -586,7 +591,7 @@ def define_google_drive_tools():
         Tool(
             schema=create_tool_schema(
                 name="google_docs_append",
-                description="Append text to the end of an existing Google Docs document. Use to add new sections, paragraphs, or updates to an existing document without overwriting existing content.",
+                description="Append text to the END of an existing Google Docs document. Use to add new sections, paragraphs, or updates without overwriting existing content. To change or fix text that is already in the document, use google_docs_replace_text instead.",
                 parameters_model=DocsAppendRequest,
             ),
             executor=None,
@@ -598,8 +603,20 @@ def define_google_drive_tools():
         Tool(
             schema=create_tool_schema(
                 name="google_docs_update",
-                description="Replace the entire content of a Google Docs document with new text. Use when you need to completely rewrite a document. WARNING: This replaces ALL existing content. Use google_docs_append to add content instead of replacing.",
+                description="Replace the ENTIRE content of a Google Docs document with new text. WARNING: This deletes ALL existing content (and formatting) and is rarely what you want. To edit specific text, prefer google_docs_replace_text; to add content, prefer google_docs_append. Only use this to deliberately rewrite a document from scratch.",
                 parameters_model=DocsUpdateRequest,
+            ),
+            executor=None,
+            service_name="google",
+        )
+    )
+
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="google_docs_replace_text",
+                description="Find and replace text in an existing Google Docs document, leaving all other content and formatting intact. This is the preferred way to edit or update a document: read it with google_docs_get, then replace the specific text you want to change. Replaces every occurrence of 'find' with 'replace' (set replace to an empty string to delete the text).",
+                parameters_model=DocsReplaceTextRequest,
             ),
             executor=None,
             service_name="google",
@@ -668,6 +685,18 @@ def define_google_drive_tools():
         )
     )
 
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="google_sheets_clear",
+                description="Clear the cell values in a Google Sheets range (A1 notation), leaving formatting intact. Use to empty a range before writing fresh data, or to remove outdated rows.",
+                parameters_model=SheetsClearRequest,
+            ),
+            executor=None,
+            service_name="google",
+        )
+    )
+
     # ----------------------------------------------------------------- Slides
 
     registry.register(
@@ -686,8 +715,44 @@ def define_google_drive_tools():
         Tool(
             schema=create_tool_schema(
                 name="google_slides_get",
-                description="Read the text content of a Google Slides presentation. Returns the title and text extracted from each slide (slide titles, body text, speaker notes text). Use to understand what a presentation contains.",
+                description="Read the content of a Google Slides presentation. Returns the title and, for each slide, its objectId (slide_id), the extracted text, and any speaker notes. Use to understand what a presentation contains and to obtain slide_id values needed by google_slides_insert_text.",
                 parameters_model=SlidesGetRequest,
+            ),
+            executor=None,
+            service_name="google",
+        )
+    )
+
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="google_slides_add_slide",
+                description="Add a new slide to an existing Google Slides presentation, optionally filling in title and body text. Use to build out or extend a presentation. Choose a layout such as 'TITLE_AND_BODY', 'TITLE_ONLY', 'SECTION_HEADER', or 'BLANK'. Returns the new slide's ID.",
+                parameters_model=SlidesAddSlideRequest,
+            ),
+            executor=None,
+            service_name="google",
+        )
+    )
+
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="google_slides_replace_text",
+                description="Find and replace text across ALL slides of a Google Slides presentation, leaving everything else intact. This is the preferred way to update or correct wording in an existing presentation. Replaces every occurrence of 'find' with 'replace' (set replace to an empty string to delete the text).",
+                parameters_model=SlidesReplaceTextRequest,
+            ),
+            executor=None,
+            service_name="google",
+        )
+    )
+
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="google_slides_insert_text",
+                description="Insert a new text box containing the given text onto a specific slide of a Google Slides presentation. Obtain the slide_id from google_slides_get. Use to add new content to a slide when there is no existing text to replace.",
+                parameters_model=SlidesInsertTextRequest,
             ),
             executor=None,
             service_name="google",

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -385,6 +385,8 @@ class ToolExecutor:
             return service.docs_append(**arguments)
         elif tool_name == "google_docs_update":
             return service.docs_update(**arguments)
+        elif tool_name == "google_docs_replace_text":
+            return service.docs_replace_text(**arguments)
 
         # Google Sheets tools
         elif tool_name == "google_sheets_create":
@@ -397,12 +399,20 @@ class ToolExecutor:
             return service.sheets_write(**arguments)
         elif tool_name == "google_sheets_append":
             return service.sheets_append(**arguments)
+        elif tool_name == "google_sheets_clear":
+            return service.sheets_clear(**arguments)
 
         # Google Slides tools
         elif tool_name == "google_slides_create":
             return service.slides_create(**arguments)
         elif tool_name == "google_slides_get":
             return service.slides_get(**arguments)
+        elif tool_name == "google_slides_add_slide":
+            return service.slides_add_slide(**arguments)
+        elif tool_name == "google_slides_replace_text":
+            return service.slides_replace_text(**arguments)
+        elif tool_name == "google_slides_insert_text":
+            return service.slides_insert_text(**arguments)
 
         # Google Places & Routes tools
         elif tool_name == "google_search_places":

--- a/src/core/tools/metadata.py
+++ b/src/core/tools/metadata.py
@@ -163,6 +163,12 @@ TOOL_METADATA: Dict[str, ToolMetadata] = {
         description="Replace all content in a Google Docs document with new text",
         category="documents",
     ),
+    "google_docs_replace_text": ToolMetadata(
+        name="google_docs_replace_text",
+        display_name="Replace Text in Google Doc",
+        description="Find and replace text in a Google Docs document, keeping other content intact",
+        category="documents",
+    ),
     # Google Sheets Tools
     "google_sheets_create": ToolMetadata(
         name="google_sheets_create",
@@ -194,6 +200,12 @@ TOOL_METADATA: Dict[str, ToolMetadata] = {
         description="Append rows to a Google Sheet after the last row with data",
         category="documents",
     ),
+    "google_sheets_clear": ToolMetadata(
+        name="google_sheets_clear",
+        display_name="Clear Google Sheet Range",
+        description="Clear cell values in a Google Sheets range, keeping formatting",
+        category="documents",
+    ),
     # Google Slides Tools
     "google_slides_create": ToolMetadata(
         name="google_slides_create",
@@ -204,7 +216,25 @@ TOOL_METADATA: Dict[str, ToolMetadata] = {
     "google_slides_get": ToolMetadata(
         name="google_slides_get",
         display_name="Read Google Slides",
-        description="Read text content from each slide in a Google Slides presentation",
+        description="Read text and speaker notes from each slide in a Google Slides presentation",
+        category="documents",
+    ),
+    "google_slides_add_slide": ToolMetadata(
+        name="google_slides_add_slide",
+        display_name="Add Google Slide",
+        description="Add a new slide with optional title and body text to a presentation",
+        category="documents",
+    ),
+    "google_slides_replace_text": ToolMetadata(
+        name="google_slides_replace_text",
+        display_name="Replace Text in Google Slides",
+        description="Find and replace text across all slides of a presentation",
+        category="documents",
+    ),
+    "google_slides_insert_text": ToolMetadata(
+        name="google_slides_insert_text",
+        display_name="Insert Text in Google Slides",
+        description="Insert a text box with the given text onto a specific slide",
         category="documents",
     ),
     # Google Places & Routes Tools

--- a/src/integrations/google/drive.py
+++ b/src/integrations/google/drive.py
@@ -1,6 +1,7 @@
 """Google Drive, Docs, Sheets, and Slides API client."""
 
 import io
+import uuid
 from typing import Any, Dict, List, Optional
 
 from google.oauth2.credentials import Credentials
@@ -376,6 +377,57 @@ class GoogleDriveClient:
             logger.error(f"Failed to update Google Doc {document_id}: {e}")
             raise
 
+    def docs_replace_text(
+        self,
+        document_id: str,
+        find: str,
+        replace: str,
+        match_case: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Find and replace text in a Google Doc without touching the rest of the content.
+
+        Args:
+            document_id: Google Doc document ID
+            find: Text to search for
+            replace: Replacement text (empty string deletes the matched text)
+            match_case: Whether the search is case-sensitive
+
+        Returns:
+            Dict with the number of occurrences changed
+        """
+        try:
+            requests = [
+                {
+                    "replaceAllText": {
+                        "containsText": {"text": find, "matchCase": match_case},
+                        "replaceText": replace,
+                    }
+                }
+            ]
+            result = self.docs.documents().batchUpdate(
+                documentId=document_id, body={"requests": requests}
+            ).execute()
+
+            replies = result.get("replies", [])
+            occurrences = 0
+            if replies:
+                occurrences = replies[0].get("replaceAllText", {}).get("occurrencesChanged", 0)
+
+            logger.info(
+                f"Replaced text in Google Doc {document_id}: {occurrences} occurrence(s)"
+            )
+            return {
+                "document_id": document_id,
+                "status": "replaced",
+                "occurrences_changed": occurrences,
+                "url": f"https://docs.google.com/document/d/{document_id}/edit",
+            }
+
+        except HttpError as e:
+            logger.error(f"Failed to replace text in Google Doc {document_id}: {e}")
+            raise
+
     # ========================================================================
     # GOOGLE SHEETS OPERATIONS
     # ========================================================================
@@ -579,6 +631,39 @@ class GoogleDriveClient:
             logger.error(f"Failed to append to Google Sheet {spreadsheet_id}: {e}")
             raise
 
+    def sheets_clear(
+        self,
+        spreadsheet_id: str,
+        range_notation: str,
+    ) -> Dict[str, Any]:
+        """
+        Clear values from a Google Sheet range (formatting is preserved).
+
+        Args:
+            spreadsheet_id: Spreadsheet ID
+            range_notation: A1 notation range to clear (e.g. 'Sheet1!A1:D10')
+
+        Returns:
+            Clear result metadata
+        """
+        try:
+            result = (
+                self.sheets.spreadsheets()
+                .values()
+                .clear(spreadsheetId=spreadsheet_id, range=range_notation, body={})
+                .execute()
+            )
+
+            logger.info(f"Cleared range {range_notation} in Sheet {spreadsheet_id}")
+            return {
+                "spreadsheet_id": spreadsheet_id,
+                "cleared_range": result.get("clearedRange"),
+            }
+
+        except HttpError as e:
+            logger.error(f"Failed to clear Google Sheet {spreadsheet_id}: {e}")
+            raise
+
     # ========================================================================
     # GOOGLE SLIDES OPERATIONS
     # ========================================================================
@@ -628,21 +713,18 @@ class GoogleDriveClient:
             slides_data = []
 
             for i, slide in enumerate(presentation.get("slides", []), 1):
-                slide_texts = []
-                for element in slide.get("pageElements", []):
-                    shape = element.get("shape", {})
-                    text_content = shape.get("text", {})
-                    for text_element in text_content.get("textElements", []):
-                        text_run = text_element.get("textRun", {})
-                        text = text_run.get("content", "").strip()
-                        if text:
-                            slide_texts.append(text)
+                slide_texts = self._extract_page_text(slide.get("pageElements", []))
+
+                # Speaker notes live on the slide's notes page.
+                notes_page = slide.get("slideProperties", {}).get("notesPage", {})
+                notes_texts = self._extract_page_text(notes_page.get("pageElements", []))
 
                 slides_data.append(
                     {
                         "slide_number": i,
                         "slide_id": slide.get("objectId"),
                         "text": " | ".join(slide_texts) if slide_texts else "(empty slide)",
+                        "speaker_notes": " ".join(notes_texts) if notes_texts else "",
                     }
                 )
 
@@ -661,9 +743,214 @@ class GoogleDriveClient:
             logger.error(f"Failed to get Slides presentation {presentation_id}: {e}")
             raise
 
+    def slides_add_slide(
+        self,
+        presentation_id: str,
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+        layout: str = "TITLE_AND_BODY",
+    ) -> Dict[str, Any]:
+        """
+        Add a new slide (with optional title/body text) to a presentation.
+
+        Args:
+            presentation_id: Presentation ID
+            title: Optional title text
+            body: Optional body text
+            layout: Predefined layout name (e.g. 'TITLE_AND_BODY', 'TITLE_ONLY', 'BLANK')
+
+        Returns:
+            Dict with the new slide's objectId
+        """
+        try:
+            slide_id = f"slide_{uuid.uuid4().hex[:12]}"
+
+            # Ask Slides to report the created placeholder object IDs so we can
+            # target them with insertText in a follow-up request.
+            placeholder_mappings = []
+            if title is not None:
+                placeholder_mappings.append(
+                    {
+                        "layoutPlaceholder": {"type": "TITLE"},
+                        "objectId": f"{slide_id}_title",
+                    }
+                )
+            if body is not None:
+                placeholder_mappings.append(
+                    {
+                        "layoutPlaceholder": {"type": "BODY"},
+                        "objectId": f"{slide_id}_body",
+                    }
+                )
+
+            create_request: Dict[str, Any] = {
+                "createSlide": {
+                    "objectId": slide_id,
+                    "slideLayoutReference": {"predefinedLayout": layout},
+                }
+            }
+            if placeholder_mappings:
+                create_request["createSlide"]["placeholderIdMappings"] = placeholder_mappings
+
+            self.slides.presentations().batchUpdate(
+                presentationId=presentation_id, body={"requests": [create_request]}
+            ).execute()
+
+            # Second pass: fill the placeholders with text.
+            text_requests = []
+            if title:
+                text_requests.append(
+                    {"insertText": {"objectId": f"{slide_id}_title", "text": title}}
+                )
+            if body:
+                text_requests.append(
+                    {"insertText": {"objectId": f"{slide_id}_body", "text": body}}
+                )
+            if text_requests:
+                self.slides.presentations().batchUpdate(
+                    presentationId=presentation_id, body={"requests": text_requests}
+                ).execute()
+
+            logger.info(f"Added slide {slide_id} to presentation {presentation_id}")
+            return {
+                "presentation_id": presentation_id,
+                "slide_id": slide_id,
+                "status": "created",
+                "url": f"https://docs.google.com/presentation/d/{presentation_id}/edit",
+            }
+
+        except HttpError as e:
+            logger.error(f"Failed to add slide to presentation {presentation_id}: {e}")
+            raise
+
+    def slides_replace_text(
+        self,
+        presentation_id: str,
+        find: str,
+        replace: str,
+        match_case: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Find and replace text across all slides of a presentation.
+
+        Args:
+            presentation_id: Presentation ID
+            find: Text to search for
+            replace: Replacement text (empty string deletes the matched text)
+            match_case: Whether the search is case-sensitive
+
+        Returns:
+            Dict with the number of occurrences changed
+        """
+        try:
+            requests = [
+                {
+                    "replaceAllText": {
+                        "containsText": {"text": find, "matchCase": match_case},
+                        "replaceText": replace,
+                    }
+                }
+            ]
+            result = self.slides.presentations().batchUpdate(
+                presentationId=presentation_id, body={"requests": requests}
+            ).execute()
+
+            replies = result.get("replies", [])
+            occurrences = 0
+            if replies:
+                occurrences = replies[0].get("replaceAllText", {}).get("occurrencesChanged", 0)
+
+            logger.info(
+                f"Replaced text in presentation {presentation_id}: {occurrences} occurrence(s)"
+            )
+            return {
+                "presentation_id": presentation_id,
+                "status": "replaced",
+                "occurrences_changed": occurrences,
+                "url": f"https://docs.google.com/presentation/d/{presentation_id}/edit",
+            }
+
+        except HttpError as e:
+            logger.error(f"Failed to replace text in presentation {presentation_id}: {e}")
+            raise
+
+    def slides_insert_text(
+        self,
+        presentation_id: str,
+        slide_id: str,
+        text: str,
+    ) -> Dict[str, Any]:
+        """
+        Insert a text box containing the given text onto a slide.
+
+        Args:
+            presentation_id: Presentation ID
+            slide_id: objectId of the target slide (from slides_get)
+            text: Text content for the new text box
+
+        Returns:
+            Dict with the new text box objectId
+        """
+        try:
+            box_id = f"textbox_{uuid.uuid4().hex[:12]}"
+
+            # EMU units: default presentation page is 10" x 5.63" (914400 EMU per inch).
+            requests = [
+                {
+                    "createShape": {
+                        "objectId": box_id,
+                        "shapeType": "TEXT_BOX",
+                        "elementProperties": {
+                            "pageObjectId": slide_id,
+                            "size": {
+                                "width": {"magnitude": 3000000, "unit": "EMU"},
+                                "height": {"magnitude": 1000000, "unit": "EMU"},
+                            },
+                            "transform": {
+                                "scaleX": 1,
+                                "scaleY": 1,
+                                "translateX": 1000000,
+                                "translateY": 1000000,
+                                "unit": "EMU",
+                            },
+                        },
+                    }
+                },
+                {"insertText": {"objectId": box_id, "text": text}},
+            ]
+            self.slides.presentations().batchUpdate(
+                presentationId=presentation_id, body={"requests": requests}
+            ).execute()
+
+            logger.info(f"Inserted text box {box_id} on slide {slide_id} ({presentation_id})")
+            return {
+                "presentation_id": presentation_id,
+                "slide_id": slide_id,
+                "text_box_id": box_id,
+                "status": "inserted",
+                "url": f"https://docs.google.com/presentation/d/{presentation_id}/edit",
+            }
+
+        except HttpError as e:
+            logger.error(f"Failed to insert text on presentation {presentation_id}: {e}")
+            raise
+
     # ========================================================================
     # INTERNAL HELPERS
     # ========================================================================
+
+    def _extract_page_text(self, page_elements: List[Dict]) -> List[str]:
+        """Extract non-empty text runs from a list of Slides page elements."""
+        texts = []
+        for element in page_elements:
+            shape = element.get("shape", {})
+            text_content = shape.get("text", {})
+            for text_element in text_content.get("textElements", []):
+                text_run = text_element.get("textRun", {})
+                text = text_run.get("content", "").strip()
+                if text:
+                    texts.append(text)
+        return texts
 
     def _format_files(self, files: List[Dict]) -> List[Dict[str, Any]]:
         return [self._format_file(f) for f in files]

--- a/src/integrations/google/drive.py
+++ b/src/integrations/google/drive.py
@@ -405,18 +405,18 @@ class GoogleDriveClient:
                     }
                 }
             ]
-            result = self.docs.documents().batchUpdate(
-                documentId=document_id, body={"requests": requests}
-            ).execute()
+            result = (
+                self.docs.documents()
+                .batchUpdate(documentId=document_id, body={"requests": requests})
+                .execute()
+            )
 
             replies = result.get("replies", [])
             occurrences = 0
             if replies:
                 occurrences = replies[0].get("replaceAllText", {}).get("occurrencesChanged", 0)
 
-            logger.info(
-                f"Replaced text in Google Doc {document_id}: {occurrences} occurrence(s)"
-            )
+            logger.info(f"Replaced text in Google Doc {document_id}: {occurrences} occurrence(s)")
             return {
                 "document_id": document_id,
                 "status": "replaced",
@@ -803,9 +803,7 @@ class GoogleDriveClient:
                     {"insertText": {"objectId": f"{slide_id}_title", "text": title}}
                 )
             if body:
-                text_requests.append(
-                    {"insertText": {"objectId": f"{slide_id}_body", "text": body}}
-                )
+                text_requests.append({"insertText": {"objectId": f"{slide_id}_body", "text": body}})
             if text_requests:
                 self.slides.presentations().batchUpdate(
                     presentationId=presentation_id, body={"requests": text_requests}
@@ -851,9 +849,11 @@ class GoogleDriveClient:
                     }
                 }
             ]
-            result = self.slides.presentations().batchUpdate(
-                presentationId=presentation_id, body={"requests": requests}
-            ).execute()
+            result = (
+                self.slides.presentations()
+                .batchUpdate(presentationId=presentation_id, body={"requests": requests})
+                .execute()
+            )
 
             replies = result.get("replies", [])
             occurrences = 0

--- a/src/models/google.py
+++ b/src/models/google.py
@@ -426,6 +426,19 @@ class DocsUpdateRequest(BaseModel):
     )
 
 
+class DocsReplaceTextRequest(BaseModel):
+    """Request model for find-and-replace within a Google Doc."""
+
+    document_id: str = Field(..., description="Google Docs document ID")
+    find: str = Field(..., description="The exact text to search for in the document")
+    replace: str = Field(
+        ..., description="The text to substitute for every occurrence of 'find' (use '' to delete)"
+    )
+    match_case: bool = Field(
+        False, description="Whether the search should be case-sensitive (default: False)"
+    )
+
+
 # Google Sheets
 
 
@@ -486,6 +499,16 @@ class SheetsAppendRequest(BaseModel):
     )
 
 
+class SheetsClearRequest(BaseModel):
+    """Request model for clearing values from a Google Sheet range."""
+
+    spreadsheet_id: str = Field(..., description="Google Sheets spreadsheet ID")
+    range_notation: str = Field(
+        ...,
+        description="A1 notation range to clear. Examples: 'Sheet1!A1:D10', 'Sheet1!A:A' (whole column). Only cell values are cleared; formatting is kept.",
+    )
+
+
 # Google Slides
 
 
@@ -502,3 +525,43 @@ class SlidesGetRequest(BaseModel):
         ...,
         description="Google Slides presentation ID (from the URL: docs.google.com/presentation/d/<ID>/edit)",
     )
+
+
+class SlidesAddSlideRequest(BaseModel):
+    """Request model for adding a new slide to a Google Slides presentation."""
+
+    presentation_id: str = Field(..., description="Google Slides presentation ID")
+    title: Optional[str] = Field(
+        None, description="Optional title text placed in the slide's title placeholder"
+    )
+    body: Optional[str] = Field(
+        None, description="Optional body text placed in the slide's body placeholder"
+    )
+    layout: str = Field(
+        "TITLE_AND_BODY",
+        description="Predefined layout for the new slide. Common values: 'TITLE_AND_BODY', 'TITLE_ONLY', 'BLANK', 'SECTION_HEADER'.",
+    )
+
+
+class SlidesReplaceTextRequest(BaseModel):
+    """Request model for find-and-replace across a Google Slides presentation."""
+
+    presentation_id: str = Field(..., description="Google Slides presentation ID")
+    find: str = Field(..., description="The exact text to search for across all slides")
+    replace: str = Field(
+        ..., description="The text to substitute for every occurrence of 'find' (use '' to delete)"
+    )
+    match_case: bool = Field(
+        False, description="Whether the search should be case-sensitive (default: False)"
+    )
+
+
+class SlidesInsertTextRequest(BaseModel):
+    """Request model for inserting a text box onto a Google Slides slide."""
+
+    presentation_id: str = Field(..., description="Google Slides presentation ID")
+    slide_id: str = Field(
+        ...,
+        description="The objectId of the slide to add the text box to (from google_slides_get, field 'slide_id')",
+    )
+    text: str = Field(..., description="Text content to place in the new text box")

--- a/src/services/google.py
+++ b/src/services/google.py
@@ -1000,6 +1000,22 @@ class GoogleService(BaseService):
         client = self._get_drive_client()
         return client.docs_update(document_id=document_id, content=content)
 
+    def docs_replace_text(
+        self,
+        document_id: str,
+        find: str,
+        replace: str,
+        match_case: bool = False,
+    ) -> Dict[str, Any]:
+        """Find and replace text within a Google Doc."""
+        client = self._get_drive_client()
+        return client.docs_replace_text(
+            document_id=document_id,
+            find=find,
+            replace=replace,
+            match_case=match_case,
+        )
+
     # ========================================================================
     # GOOGLE SHEETS OPERATIONS
     # ========================================================================
@@ -1064,6 +1080,14 @@ class GoogleService(BaseService):
             values=values,
         )
 
+    def sheets_clear(self, spreadsheet_id: str, range_notation: str) -> Dict[str, Any]:
+        """Clear values from a Google Sheet range (formatting preserved)."""
+        client = self._get_drive_client()
+        return client.sheets_clear(
+            spreadsheet_id=spreadsheet_id,
+            range_notation=range_notation,
+        )
+
     # ========================================================================
     # GOOGLE SLIDES OPERATIONS
     # ========================================================================
@@ -1087,6 +1111,52 @@ class GoogleService(BaseService):
         """Get the content of a Google Slides presentation."""
         client = self._get_drive_client()
         return client.slides_get(presentation_id=presentation_id)
+
+    def slides_add_slide(
+        self,
+        presentation_id: str,
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+        layout: str = "TITLE_AND_BODY",
+    ) -> Dict[str, Any]:
+        """Add a new slide (with optional title/body) to a presentation."""
+        client = self._get_drive_client()
+        return client.slides_add_slide(
+            presentation_id=presentation_id,
+            title=title,
+            body=body,
+            layout=layout,
+        )
+
+    def slides_replace_text(
+        self,
+        presentation_id: str,
+        find: str,
+        replace: str,
+        match_case: bool = False,
+    ) -> Dict[str, Any]:
+        """Find and replace text across a Google Slides presentation."""
+        client = self._get_drive_client()
+        return client.slides_replace_text(
+            presentation_id=presentation_id,
+            find=find,
+            replace=replace,
+            match_case=match_case,
+        )
+
+    def slides_insert_text(
+        self,
+        presentation_id: str,
+        slide_id: str,
+        text: str,
+    ) -> Dict[str, Any]:
+        """Insert a text box onto a slide."""
+        client = self._get_drive_client()
+        return client.slides_insert_text(
+            presentation_id=presentation_id,
+            slide_id=slide_id,
+            text=text,
+        )
 
     def complete_oauth(self, authorization_code: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Users reported the Google integration was poor at updating existing Docs,
Sheets, and Slides. The gap was missing tools, not scopes: the documents,
spreadsheets, and presentations scopes already grant full read/write, but the
only post-create options were destructive (docs_update replaced ALL content)
or non-existent (Slides had no update tool at all despite the write scope).

New tools, all within existing scopes (no scope changes):
- google_docs_replace_text: non-destructive find-and-replace in a Doc
- google_sheets_clear: clear a range's values (keeps formatting)
- google_slides_add_slide: add a slide with optional title/body
- google_slides_replace_text: find-and-replace across a presentation
- google_slides_insert_text: insert a text box onto a slide

Also:
- Fix google_slides_get description/behaviour mismatch: it now actually reads
  speaker notes (previously claimed to but did not) and returns slide_id.
- Reword docs_update/docs_append descriptions to steer the model toward the
  non-destructive replace tool for edits.
- Migration 057 wires the new tools into the writer and file_handler agents;
  the research agent stays read-only.

Wired across all layers: request models, GoogleDriveClient, GoogleService,
tool definitions, executor dispatch, display metadata, and docs.