### PR TITLE
feat(outlook): add summary_mode to outlook_read_emails and outlook_search_emails

### DIFF
--- a/src/models/outlook.py
+++ b/src/models/outlook.py
@@ -11,6 +11,15 @@ class ReadEmailsRequest(BaseModel):
         None,
         description="OData filter query to narrow results (e.g. \"from/emailAddress/address eq 'user@example.com'\")",
     )
+    summary_mode: bool = Field(
+        True,
+        description=(
+            "When true (default), returns a compact representation per email: plain-text body "
+            "(truncated to 1000 chars), essential fields only (id, subject, receivedDateTime, "
+            "from, bodyPreview, body_text, hasAttachments, toRecipients, ccRecipients). "
+            "Set to false only when you need the raw HTML body or full Graph API metadata."
+        ),
+    )
 
 
 class SendEmailRequest(BaseModel):
@@ -79,6 +88,15 @@ class SearchEmailsRequest(BaseModel):
         "inbox", description="Mail folder to search in (inbox, sentitems, drafts, etc.)"
     )
     limit: int = Field(20, description="Maximum results", ge=1, le=100)
+    summary_mode: bool = Field(
+        True,
+        description=(
+            "When true (default), returns a compact representation per email: plain-text body "
+            "(truncated to 1000 chars), essential fields only (id, subject, receivedDateTime, "
+            "from, bodyPreview, body_text, hasAttachments, toRecipients, ccRecipients). "
+            "Set to false only when you need the raw HTML body or full Graph API metadata."
+        ),
+    )
 
 
 class CreateDraftRequest(BaseModel):

--- a/src/services/outlook.py
+++ b/src/services/outlook.py
@@ -1,7 +1,9 @@
 """Outlook service for email, calendar, and OneDrive operations."""
 
+import re
 import threading
 from datetime import datetime, timedelta, timezone
+from html.parser import HTMLParser
 from typing import Any, Dict, List, Optional
 
 from dateutil import parser as dateutil_parser
@@ -107,6 +109,87 @@ def _normalize_calendar_date(value: Optional[str], boundary: str = "start") -> O
     )
 
 
+_BODY_TEXT_LIMIT = 1000
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Extracts plain text from HTML, skipping style/script blocks."""
+
+    _SKIP_TAGS = frozenset({"style", "script", "head"})
+    _BLOCK_TAGS = frozenset({"p", "div", "br", "tr", "li", "td", "th", "h1", "h2", "h3", "h4", "h5", "h6"})
+
+    def __init__(self):
+        super().__init__()
+        self._parts: List[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        tag_lower = tag.lower()
+        if tag_lower in self._SKIP_TAGS:
+            self._skip_depth += 1
+        elif tag_lower in self._BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag.lower() in self._SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._parts)
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+
+def _html_to_text(html_content: str) -> str:
+    extractor = _HTMLTextExtractor()
+    try:
+        extractor.feed(html_content)
+    except Exception:
+        pass
+    return extractor.get_text()
+
+
+def _summarize_email(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a compact, LLM-friendly representation of a Graph API message object."""
+    body = msg.get("body", {})
+    content = body.get("content", "")
+    content_type = body.get("contentType", "text").lower()
+
+    body_text = _html_to_text(content) if content_type == "html" else content.strip()
+    if len(body_text) > _BODY_TEXT_LIMIT:
+        body_text = body_text[:_BODY_TEXT_LIMIT] + "..."
+
+    def _addrs(recipients):
+        return [
+            r["emailAddress"]["address"]
+            for r in (recipients or [])
+            if r.get("emailAddress", {}).get("address")
+        ]
+
+    from_field = msg.get("from") or msg.get("sender") or {}
+    from_addr = from_field.get("emailAddress", {})
+
+    return {
+        "id": msg.get("id", ""),
+        "subject": msg.get("subject", ""),
+        "receivedDateTime": msg.get("receivedDateTime", ""),
+        "from": {
+            "name": from_addr.get("name", ""),
+            "address": from_addr.get("address", ""),
+        },
+        "bodyPreview": msg.get("bodyPreview", ""),
+        "body_text": body_text,
+        "hasAttachments": msg.get("hasAttachments", False),
+        "toRecipients": _addrs(msg.get("toRecipients")),
+        "ccRecipients": _addrs(msg.get("ccRecipients")),
+    }
+
+
 class OutlookService(BaseService):
     """Service for Outlook/Microsoft Graph integration."""
 
@@ -177,12 +260,20 @@ class OutlookService(BaseService):
 
     # Mail operations
     def read_emails(
-        self, folder: str = "inbox", limit: int = 10, query: Optional[str] = None
+        self,
+        folder: str = "inbox",
+        limit: int = 10,
+        query: Optional[str] = None,
+        summary_mode: bool = True,
     ) -> List[Dict[str, Any]]:
         client = self._get_client()
         if query:
-            return client.search_emails(query=query, folder=folder, limit=limit)
-        return client.list_messages(folder=folder, limit=limit)
+            messages = client.search_emails(query=query, folder=folder, limit=limit)
+        else:
+            messages = client.list_messages(folder=folder, limit=limit)
+        if summary_mode:
+            return [_summarize_email(m) for m in messages]
+        return messages
 
     def send_email(self, to: List[str], subject: str, body: str, **kwargs) -> bool:
         client = self._get_client()
@@ -279,7 +370,7 @@ class OutlookService(BaseService):
         return client.get_message(message_id=message_id)
 
     def search_emails(
-        self, query: str, folder: str = "inbox", limit: int = 20
+        self, query: str, folder: str = "inbox", limit: int = 20, summary_mode: bool = True
     ) -> List[Dict[str, Any]]:
         """
         Search emails by query string.
@@ -288,12 +379,16 @@ class OutlookService(BaseService):
             query: Search query
             folder: Mail folder to search in
             limit: Maximum results
+            summary_mode: When True, returns compact plain-text summaries instead of raw Graph payloads
 
         Returns:
             List of matching messages
         """
         client = self._get_client()
-        return client.search_emails(query=query, folder=folder, limit=limit)
+        messages = client.search_emails(query=query, folder=folder, limit=limit)
+        if summary_mode:
+            return [_summarize_email(m) for m in messages]
+        return messages
 
     def create_draft(
         self,

--- a/src/services/outlook.py
+++ b/src/services/outlook.py
@@ -116,7 +116,9 @@ class _HTMLTextExtractor(HTMLParser):
     """Extracts plain text from HTML, skipping style/script blocks."""
 
     _SKIP_TAGS = frozenset({"style", "script", "head"})
-    _BLOCK_TAGS = frozenset({"p", "div", "br", "tr", "li", "td", "th", "h1", "h2", "h3", "h4", "h5", "h6"})
+    _BLOCK_TAGS = frozenset(
+        {"p", "div", "br", "tr", "li", "td", "th", "h1", "h2", "h3", "h4", "h5", "h6"}
+    )
 
     def __init__(self):
         super().__init__()
@@ -150,6 +152,7 @@ def _html_to_text(html_content: str) -> str:
     try:
         extractor.feed(html_content)
     except Exception:
+        # HTMLParser.feed may raise on severely malformed HTML; return partial extraction
         pass
     return extractor.get_text()
 


### PR DESCRIPTION
## Summary

- Adds a `summary_mode` parameter (`bool`, default `true`) to `outlook_read_emails` and `outlook_search_emails`
- When enabled, each email is converted to a compact plain-text representation instead of returning the raw Microsoft Graph API payload
- No new dependencies — HTML stripping is done with stdlib `html.parser`

## What changes

**`src/models/outlook.py`**
- `ReadEmailsRequest`: new `summary_mode: bool = True` field
- `SearchEmailsRequest`: new `summary_mode: bool = True` field

**`src/services/outlook.py`**
- `_HTMLTextExtractor`: minimal `HTMLParser` subclass that skips `<style>`/`<script>`/`<head>` blocks and collapses whitespace
- `_html_to_text()`: feeds HTML into the extractor and returns clean plain text
- `_summarize_email()`: converts a raw Graph message object into a compact dict with whitelisted fields only
- `OutlookService.read_emails()` / `search_emails()`: accept `summary_mode` and apply `_summarize_email()` to each result when `True`

## Summary mode output shape

```json
{
  "id": "AAMkADEw...",
  "subject": "Re: Project proposal",
  "receivedDateTime": "2026-07-22T12:21:43Z",
  "from": { "name": "Alice Example", "address": "alice@example.com" },
  "bodyPreview": "Dear Alice...",
  "body_text": "Dear Alice,\n\nThis is the plain-text body truncated to 1000 chars...",
  "hasAttachments": false,
  "toRecipients": ["bob@example.com"],
  "ccRecipients": ["carol@example.com"]
}
```

Dropped fields: `@odata.etag`, `changeKey`, `conversationId`, `conversationIndex`, `webLink`, `parentFolderId`, `internetMessageId`, `categories`, `flag`, `inferenceClassification`, `isRead`, `isDraft`, `isDeliveryReceiptRequested`, `isReadReceiptRequested`, `sender` (duplicate of `from`), `bccRecipients`, `replyTo`, `sentDateTime`, `createdDateTime`, `lastModifiedDateTime`

## Expected impact

| | Current (raw) | `summary_mode=true` |
|---|---|---|
| Size per email | ~22 KB | ~1–2 KB |
| 100 emails | ~2.2 MB | ~100–200 KB |
| Needs temp-file offload | Often | No |
| Needs python_agent to parse HTML | Yes | No |

Defaulting to `true` prevents payload bloat from silently affecting every email-touching workflow. Callers that need the raw HTML body or full metadata can pass `summary_mode=false`.