### PR TITLE
Add skill pinning and task persistence for async sub-tasks

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,4 +1,21 @@
-"""Base classes and models for agent definitions."""
+"""Admin-facing model for agent/skill definitions.
+
+``AgentDefinition`` is the *admin API view* of a row in the
+``agent_definitions`` table.  The same table is read at runtime by the
+``Skill`` model (``src/models/skill.py``), which is the live orchestration
+view: it maps ``backstory`` → ``context_prompt``, ``role`` → ``category``,
+and ``goal`` → ``description``.
+
+In other words:
+- **Skill** (runtime) — what the LLM uses: context-prompt, tools, intent-keywords.
+- **AgentDefinition** (admin API) — what the admin UI reads/writes: role, goal,
+  backstory, allow_delegation, etc.
+
+Both point at the same rows.  There is no separate CrewAI crew or delegating
+agent runtime; the ``allow_delegation`` field and the coordinator's "delegate"
+goal are preserved for admin UI clarity, but delegation is now handled by the
+``dispatch_task`` LLM tool (``src/services/async_task_dispatcher.py``).
+"""
 
 import json
 from dataclasses import dataclass, field
@@ -9,9 +26,17 @@ from typing import Any, Dict, List, Optional
 @dataclass
 class AgentDefinition:
     """
-    Database model for agent definitions.
+    Admin API view of a row in the ``agent_definitions`` table.
 
-    Represents a CrewAI agent configuration stored in the database.
+    This dataclass is used by the admin REST API (``src/api/agents.py``) and
+    the ``AgentRegistry`` to read, create, update, and reorder specialist
+    definitions.  It is *not* used at LLM request time — the runtime system
+    reads the same rows via ``Skill`` (``src/models/skill.py``).
+
+    Fields mirror the DB schema.  ``backstory`` holds the context-prompt text
+    that the LLM receives as a skill section; ``allow_delegation`` is an
+    admin toggle (delegation is carried out via ``dispatch_task``, not by a
+    separate agent runtime).
     """
 
     id: Optional[int] = None
@@ -110,7 +135,7 @@ DEFAULT_AGENTS = {
         "name": "coordinator",
         "display_name": "Coordinator Agent",
         "role": "Task Coordinator",
-        "goal": "Understand user intent, create an actionable plan, and delegate to specialist agents who MUST use their tools to fulfill the request",
+        "goal": "Understand user intent, create an actionable plan, and use dispatch_task to delegate independent sub-tasks to specialist skills (research, writer, communication, etc.) that run in parallel",
         "backstory": "",
         "tools": [],
         "enabled": True,

--- a/src/agents/registry.py
+++ b/src/agents/registry.py
@@ -1,6 +1,15 @@
 """
-Agent registry for managing agent definitions.
-Provides CRUD operations for agent definitions stored in the database.
+Agent registry for managing agent/skill definitions (admin API layer).
+
+The ``AgentRegistry`` provides CRUD operations for rows in the
+``agent_definitions`` table as seen through the ``AgentDefinition``
+admin model.  The same rows are consumed at runtime by the ``Skill``
+model and ``SkillRepository`` (``src/core/repositories/skill.py``).
+
+Use ``AgentRegistry`` when you need to create, update, reorder, or
+assign tools to specialists via the admin API.  Use ``SkillRepository``
+(or ``skill_repo`` from dependency injection) when you need to select
+skills at request time.
 """
 
 import json
@@ -16,10 +25,12 @@ logger = logging.getLogger(__name__)
 
 class AgentRegistry:
     """
-    Registry for managing agent definitions.
+    Registry for managing agent/skill definitions (admin API layer).
 
-    Handles database operations for agent configurations and provides
-    factory methods for creating CrewAI agents.
+    Handles database CRUD for ``agent_definitions`` rows via the
+    ``AgentDefinition`` admin model.  Does not interact with the
+    live request-handling path; that is the responsibility of
+    ``SkillRepository`` and ``MessageHandler``.
     """
 
     def __init__(self, db_manager: DatabaseManager):

--- a/src/core/dependencies.py
+++ b/src/core/dependencies.py
@@ -839,6 +839,7 @@ def get_message_handler(
     memory_service=Depends(get_memory_service),
     settings_service=Depends(get_settings_service),
     tool_executor=Depends(get_tool_executor),
+    task_repo=Depends(get_agent_task_repo),
 ):
     """
     Get message handler instance.
@@ -849,6 +850,7 @@ def get_message_handler(
         memory_service: Memory service (injected)
         settings_service: Settings service (injected)
         tool_executor: Tool executor (injected)
+        task_repo: Agent task repository for persisting async sub-task state (injected)
 
     Returns:
         MessageHandler instance
@@ -863,4 +865,5 @@ def get_message_handler(
         tool_executor=tool_executor,
         max_iterations=15,
         max_skills_per_request=5,
+        task_repo=task_repo,
     )

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -2598,7 +2598,7 @@ def define_async_task_tools():
     """
     registry = get_tool_registry()
 
-    # dispatch_task — spawn a background sub-task
+    # dispatch_task — spawn a background sub-task, optionally as a named specialist
     registry.register(
         Tool(
             schema=create_tool_schema(
@@ -2609,6 +2609,11 @@ def define_async_task_tools():
                     "access — identical to a top-level user request. Use this when a plan step "
                     "involves substantial independent work (research, multi-step writing, "
                     "analysis) that can run in parallel with other steps. "
+                    "Set the optional 'skill' parameter to delegate to a named specialist "
+                    "(e.g. skill='research' to pin to the Research Agent's context and tools, "
+                    "skill='writer' for the Content Writer, skill='communication' for email/chat). "
+                    "When 'skill' is omitted the sub-task performs its own automatic skill "
+                    "selection based on its description. "
                     "Returns a task_id immediately. Use get_task_result to poll for completion "
                     "and retrieve the result. Multiple tasks can run simultaneously."
                 ),

--- a/src/models/plan_tools.py
+++ b/src/models/plan_tools.py
@@ -4,6 +4,19 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+# Names of built-in specialist skills that can be pinned via dispatch_task.
+# Keep this in sync with the agent_definitions table seed data.
+SPECIALIST_SKILL_NAMES = [
+    "research",
+    "communication",
+    "writer",
+    "file_handler",
+    "planner",
+    "navigator",
+    "browser",
+    "system",
+]
+
 
 class RevisePlanRequest(BaseModel):
     """Request to revise the remaining steps in the current execution plan.
@@ -70,6 +83,11 @@ class DispatchTaskRequest(BaseModel):
     The sub-task runs independently with its own planning loop and tool
     access.  The caller receives a task_id immediately and can poll with
     get_task_result to retrieve the outcome.
+
+    When ``skill`` is provided the sub-task is pinned to that specialist:
+    it receives only that skill's context prompt and tools, bypassing
+    keyword-based skill selection.  This is the recommended way to delegate
+    work to a named specialist (e.g. 'research', 'writer').
     """
 
     description: str = Field(
@@ -84,6 +102,16 @@ class DispatchTaskRequest(BaseModel):
         description=(
             "Optional context from the current conversation to pass to the sub-task "
             "(e.g. user preferences, intermediate results that inform this work)."
+        ),
+    )
+    skill: Optional[str] = Field(
+        default=None,
+        description=(
+            "Name of the specialist skill to run this sub-task as. "
+            "When set, the sub-task uses only that skill's context prompt and tools, "
+            "bypassing keyword-based skill selection. "
+            f"Available specialists: {', '.join(SPECIALIST_SKILL_NAMES)}. "
+            "Omit to let the sub-task perform its own automatic skill selection."
         ),
     )
 

--- a/src/models/skill.py
+++ b/src/models/skill.py
@@ -1,4 +1,23 @@
-"""Skill model for the skills-based LLM system."""
+"""Skill model for the skills-based LLM system.
+
+A ``Skill`` is the *runtime* view of a row in the ``agent_definitions``
+table.  The same table also has an *admin* view (``AgentDefinition`` in
+``src/agents/base.py``) used by the REST API and admin UI.
+
+Field mapping (DB → Skill):
+  backstory       → context_prompt   (text injected into the LLM system prompt)
+  role            → category         (grouping label)
+  goal            → description      (brief capability summary)
+  intent_keywords → intent_keywords  (keywords for automatic skill selection)
+  tools           → tools            (tool names available to this skill)
+
+Skills replace the previous CrewAI agent delegation model.  Instead of
+routing between agents, the single LLM is given the context-prompts and
+tools of all skills that match the request's intent, then executes a
+tool-calling loop.  Parallel fan-out is achieved via the ``dispatch_task``
+tool (``src/services/async_task_dispatcher.py``), which can pin a sub-task
+to a specific skill via the ``pinned_skill`` param on ``handle_message``.
+"""
 
 import json
 from typing import Any, Dict, List, Optional

--- a/src/services/async_task_dispatcher.py
+++ b/src/services/async_task_dispatcher.py
@@ -7,12 +7,17 @@ skill selection, planning, and tool execution.
 
 Typical flow
 ------------
-1. Main handler calls ``dispatch(description, context)`` → returns *task_id*.
+1. Main handler calls ``dispatch(description, context, skill)`` → returns *task_id*.
 2. A background asyncio.Task runs ``handle_message`` for the description.
+   If *skill* is provided, the sub-task is pinned to that specialist's
+   context-prompt and tool set, bypassing keyword-based skill selection.
 3. The caller uses ``wait_for_tasks`` (LLM tool) to block until all
    dispatched tasks finish, then retrieves their results.
 4. The main loop refuses to return a final response while any sub-tasks
    are still running, guaranteeing no tasks are left unmonitored.
+5. Each sub-task is persisted to the ``agent_tasks`` table via the
+   optional ``AgentTaskRepository`` so state survives restarts and is
+   visible in the admin UI.
 """
 
 import asyncio
@@ -32,6 +37,7 @@ class AsyncTask:
 
     task_id: str
     description: str
+    skill: Optional[str] = None  # pinned specialist skill name, if any
     status: str = "running"  # running | completed | failed
     result: str = ""
     error: str = ""
@@ -47,6 +53,7 @@ class AsyncTask:
             "task_id": self.task_id,
             "description": self.description,
             "status": self.status,
+            **({"skill": self.skill} if self.skill else {}),
             # Only include result / error when relevant to reduce token waste
             **({"result": self.result} if self.status == "completed" else {}),
             **({"error": self.error} if self.status == "failed" else {}),
@@ -62,32 +69,55 @@ class AsyncTaskDispatcher:
 
     Each sub-task is a full ``handle_message`` invocation — it gets its own
     skill selection, planning loop, and stuck detection, identical to a
-    top-level user request.  Sub-tasks can themselves dispatch further
-    sub-tasks, enabling arbitrary depth of parallel work.
+    top-level user request.  When *skill* is provided, the sub-task is
+    pinned to that specialist's context-prompt and tool set instead of
+    re-running keyword-based skill selection.
+
+    Sub-tasks can themselves dispatch further sub-tasks, enabling arbitrary
+    depth of parallel work.
 
     The ``wait_for`` coroutine is used by the ``wait_for_tasks`` inline tool
     handler to properly block until a set of tasks has finished (with an
     optional timeout), after which the main loop can collect results and
     respond to the user.
+
+    Task state is persisted to the ``agent_tasks`` table when a
+    ``task_repo`` is provided, making sub-task progress visible after
+    restarts.
     """
 
-    def __init__(self, handle_message_fn: Callable) -> None:
+    def __init__(self, handle_message_fn: Callable, task_repo=None) -> None:
         """
         Args:
             handle_message_fn: Async callable with the signature::
 
-                handle_message(message: str, channel: str = "subtask") -> dict
+                handle_message(
+                    message: str,
+                    channel: str = "subtask",
+                    pinned_skill: Optional[str] = None,
+                ) -> dict
 
             Typically ``MessageHandler.handle_message`` bound to an instance.
+
+            task_repo: Optional ``AgentTaskRepository`` instance.  When
+                provided, each dispatched task is persisted to the
+                ``agent_tasks`` database table.
         """
         self._handle_message = handle_message_fn
+        self._task_repo = task_repo
         self._tasks: Dict[str, AsyncTask] = {}
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def dispatch(self, description: str, context: str = "") -> str:
+    def dispatch(
+        self,
+        description: str,
+        context: str = "",
+        skill: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+    ) -> str:
         """
         Dispatch *description* as an async sub-task.
 
@@ -95,6 +125,11 @@ class AsyncTaskDispatcher:
             description: Self-contained instruction for the sub-task.
             context: Optional context from the parent conversation (e.g.
                 earlier results, user preferences).
+            skill: Optional specialist skill name to pin for this sub-task.
+                When set, the sub-task uses only that skill's context-prompt
+                and tools rather than running keyword-based skill selection.
+            conversation_id: Parent conversation ID, used when persisting the
+                task record to the ``agent_tasks`` table.
 
         Returns:
             A short *task_id* string (8 hex chars).  Pass this to
@@ -105,13 +140,38 @@ class AsyncTaskDispatcher:
         if context:
             message = f"Context from parent task:\n{context}\n\nTask: {description}"
 
-        task = AsyncTask(task_id=task_id, description=description)
+        task = AsyncTask(task_id=task_id, description=description, skill=skill)
         self._tasks[task_id] = task
 
-        asyncio_task = asyncio.create_task(self._run(task, message), name=f"subtask-{task_id}")
+        # Persist the task record so state survives restarts and is visible
+        # in the admin UI.
+        if self._task_repo:
+            try:
+                self._task_repo.create_task(
+                    task_id=task_id,
+                    conversation_id=conversation_id or "",
+                    agent_name=skill or "auto",
+                    action="dispatch_task",
+                    parameters={
+                        "description": description,
+                        "context": context,
+                        "skill": skill,
+                    },
+                    status="running",
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to persist sub-task {task_id} to DB: {exc}")
+
+        asyncio_task = asyncio.create_task(
+            self._run(task, message, task_id), name=f"subtask-{task_id}"
+        )
         task._asyncio_task = asyncio_task
 
-        logger.info(f"Dispatched sub-task {task_id}: {description[:100]}")
+        logger.info(
+            f"Dispatched sub-task {task_id}"
+            + (f" [skill={skill}]" if skill else "")
+            + f": {description[:100]}"
+        )
         return task_id
 
     def get_status(self, task_id: str) -> Optional[Dict[str, Any]]:
@@ -176,13 +236,38 @@ class AsyncTaskDispatcher:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _run(self, task: AsyncTask, message: str) -> None:
+    async def _run(self, task: AsyncTask, message: str, task_id: str) -> None:
         """Execute the task and record the outcome."""
+        started_at = datetime.now(timezone.utc)
+
+        # Mark as running in DB (already created as 'running', but update
+        # started_at so the timestamp is accurate after any queue delay).
+        if self._task_repo:
+            try:
+                self._task_repo.update_task_status(
+                    task_id=task_id, status="running", started_at=started_at
+                )
+            except Exception as exc:
+                logger.debug(f"Sub-task {task_id}: failed to update started_at in DB: {exc}")
+
+        # Initialise DB-write locals before the try/except so `finally`
+        # always has valid values even if an unexpected error escapes both branches.
+        db_result: Optional[Dict[str, Any]] = None
+        db_status: str = "failed"
+        db_error: Optional[str] = None
+
         try:
-            result = await self._handle_message(message=message, channel="subtask")
+            result = await self._handle_message(
+                message=message,
+                channel="subtask",
+                pinned_skill=task.skill,
+            )
             task.status = "completed"
             task.result = result.get("response", "")
             task.tools_executed = result.get("tools_executed", [])
+            db_result = {"response": task.result, "tools_executed": task.tools_executed}
+            db_status = "completed"
+            db_error = None
         except Exception as exc:
             logger.error(
                 f"Sub-task {task.task_id} failed: {exc}",
@@ -190,6 +275,9 @@ class AsyncTaskDispatcher:
             )
             task.status = "failed"
             task.error = str(exc)
+            db_result = None
+            db_status = "failed"
+            db_error = str(exc)
         finally:
             task.completed_at = datetime.now(timezone.utc)
             tool_count = len(task.tools_executed)
@@ -197,3 +285,18 @@ class AsyncTaskDispatcher:
                 f"Sub-task {task.task_id} {task.status}"
                 + (f" ({tool_count} tools executed)" if tool_count else "")
             )
+
+            # Persist final state to DB.
+            if self._task_repo:
+                try:
+                    self._task_repo.update_task_status(
+                        task_id=task_id,
+                        status=db_status,
+                        completed_at=task.completed_at,
+                        result=db_result,
+                        error_message=db_error,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        f"Sub-task {task_id}: failed to persist final state to DB: {exc}"
+                    )

--- a/src/services/async_task_dispatcher.py
+++ b/src/services/async_task_dispatcher.py
@@ -297,6 +297,4 @@ class AsyncTaskDispatcher:
                         error_message=db_error,
                     )
                 except Exception as exc:
-                    logger.debug(
-                        f"Sub-task {task_id}: failed to persist final state to DB: {exc}"
-                    )
+                    logger.debug(f"Sub-task {task_id}: failed to persist final state to DB: {exc}")

--- a/src/services/message_handler.py
+++ b/src/services/message_handler.py
@@ -51,6 +51,7 @@ class MessageHandler:
         tool_executor: ToolExecutor,
         max_iterations: int = 15,
         max_skills_per_request: int = 5,
+        task_repo=None,
     ):
         self.skill_repo = skill_repo
         self.conversation_service = conversation_service
@@ -63,7 +64,9 @@ class MessageHandler:
 
         # Dispatcher for async sub-tasks — bound to this handler instance so
         # sub-tasks share the same services and configuration.
-        self.async_task_dispatcher = AsyncTaskDispatcher(self.handle_message)
+        # task_repo (AgentTaskRepository) is optional; when present, every
+        # dispatched sub-task is persisted to the agent_tasks table.
+        self.async_task_dispatcher = AsyncTaskDispatcher(self.handle_message, task_repo=task_repo)
 
         logger.info(
             f"MessageHandler initialized (max_iterations={max_iterations}, "
@@ -100,6 +103,7 @@ class MessageHandler:
         image_base64: Optional[str] = None,
         image_mimetype: Optional[str] = None,
         event_callback: Optional[Callable[[dict], Awaitable[None]]] = None,
+        pinned_skill: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Handle a user message through the skills-based LLM system.
@@ -198,12 +202,35 @@ class MessageHandler:
                 f"recent_messages={len(context.get('recent_messages', []))}"
             )
 
-            # Step 4: Select relevant skills
+            # Step 4: Select relevant skills.
+            # When this call comes from a dispatched sub-task with a pinned
+            # specialist skill, bypass keyword-based selection and use only
+            # that skill's context-prompt and tools.
             logger.debug("Step 4: Selecting skills...")
-            selection_message = self._contextualize_message_for_skill_selection(
-                message, context.get("recent_messages", [])
-            )
-            selected_skills = self._select_skills(selection_message, conversation_id=conv_id)
+            if pinned_skill:
+                pinned = self.skill_repo.get_skill_by_name(pinned_skill)
+                if pinned:
+                    selected_skills = [pinned]
+                    logger.info(
+                        f"Sub-task pinned to specialist skill '{pinned_skill}'; "
+                        "bypassing keyword selection"
+                    )
+                else:
+                    logger.warning(
+                        f"Pinned skill '{pinned_skill}' not found in DB; "
+                        "falling back to keyword selection"
+                    )
+                    selection_message = self._contextualize_message_for_skill_selection(
+                        message, context.get("recent_messages", [])
+                    )
+                    selected_skills = self._select_skills(
+                        selection_message, conversation_id=conv_id
+                    )
+            else:
+                selection_message = self._contextualize_message_for_skill_selection(
+                    message, context.get("recent_messages", [])
+                )
+                selected_skills = self._select_skills(selection_message, conversation_id=conv_id)
             logger.debug(
                 f"Selected {len(selected_skills)} skills: {[s.name for s in selected_skills]}"
             )
@@ -267,9 +294,22 @@ class MessageHandler:
             # Planning is best-effort; if it fails we proceed without a plan
             logger.warning(f"Plan generation failed, proceeding without plan: {e}")
 
-        # When a plan is active, inject adaptive planning tools (revise_plan, ask_user)
-        if plan and plan.total > 1:
+        # Inject adaptive planning + async-dispatch tools when:
+        # - a multi-step plan is active, OR
+        # - ≥2 skills were selected (multi-service request that may benefit
+        #   from parallel fan-out even without an explicit plan), OR
+        # - this is not a pinned sub-task (pinned sub-tasks are focused single
+        #   specialists that don't need to delegate further).
+        should_inject_dispatch = (plan and plan.total > 1) or (
+            not pinned_skill and len(selected_skills) >= 2
+        )
+        if should_inject_dispatch:
             tools = self._inject_plan_tools(tools)
+            logger.debug(
+                "Injected plan+dispatch tools "
+                f"(plan_steps={plan.total if plan else 0}, "
+                f"skills={len(selected_skills)}, pinned={pinned_skill})"
+            )
 
         # Step 9: Execute conversation loop
         try:
@@ -1225,8 +1265,20 @@ class MessageHandler:
                 if tool_name == "dispatch_task":
                     description = arguments.get("description", "")
                     context = arguments.get("context", "")
-                    logger.info(f"dispatch_task called: {description[:100]}")
-                    task_id = self.async_task_dispatcher.dispatch(description, context)
+                    skill_name = arguments.get("skill") or None
+                    logger.info(
+                        f"dispatch_task called: {description[:100]}"
+                        + (f" [skill={skill_name}]" if skill_name else "")
+                    )
+                    task_id = self.async_task_dispatcher.dispatch(
+                        description,
+                        context,
+                        skill=skill_name,
+                        conversation_id=conversation_id,
+                    )
+                    skill_note = (
+                        f" It will run as the '{skill_name}' specialist." if skill_name else ""
+                    )
                     tool_results.append(
                         {
                             "role": "tool",
@@ -1235,8 +1287,9 @@ class MessageHandler:
                                 {
                                     "task_id": task_id,
                                     "status": "running",
+                                    "skill": skill_name,
                                     "message": (
-                                        f"Sub-task dispatched with ID '{task_id}'. "
+                                        f"Sub-task dispatched with ID '{task_id}'.{skill_note} "
                                         f"Call get_task_result(task_id='{task_id}') "
                                         "to check progress and retrieve the result."
                                     ),


### PR DESCRIPTION
## Summary
This PR enhances the async task dispatcher to support pinning sub-tasks to specific specialist skills and persisting task state to the database. Sub-tasks can now be delegated to named specialists (e.g., 'research', 'writer', 'communication') with their own context-prompts and tools, and their execution state is tracked in the `agent_tasks` table for visibility and restart resilience.

## Key Changes

- **Skill Pinning**: Added optional `skill` parameter to `dispatch()` and `handle_message()` to pin sub-tasks to specific specialist skills, bypassing keyword-based skill selection. When a skill is pinned, the sub-task receives only that skill's context-prompt and tools.

- **Task Persistence**: Integrated optional `AgentTaskRepository` into `AsyncTaskDispatcher` to persist task records to the `agent_tasks` table. Task state (created, started, completed/failed) is now tracked with timestamps and results, making sub-task progress visible in the admin UI and surviving service restarts.

- **Selective Tool Injection**: Updated tool injection logic to provide `dispatch_task` and planning tools when:
  - A multi-step plan is active, OR
  - Multiple skills are selected (enabling parallel fan-out), OR
  - The request is not a pinned sub-task (focused specialists don't need further delegation)

- **Enhanced Logging**: Improved logging to show skill pinning status and task persistence outcomes, with graceful degradation if DB operations fail.

- **Documentation Updates**: 
  - Clarified the distinction between `Skill` (runtime view) and `AgentDefinition` (admin API view) of the same database rows
  - Updated docstrings to explain skill pinning, task persistence, and the shift from CrewAI delegation to `dispatch_task`-based parallelism
  - Added `SPECIALIST_SKILL_NAMES` constant documenting available pinnable skills

- **API Enhancements**: 
  - `DispatchTaskRequest` now includes optional `skill` field with documentation and available specialist names
  - `dispatch_task` tool description updated to explain skill pinning
  - Coordinator agent goal updated to reflect delegation via `dispatch_task` rather than agent-to-agent routing

## Implementation Details

- Task state is initialized as "running" on dispatch, then updated with `started_at` timestamp when execution begins, and finally updated with `completed_at`, result/error, and final status when the sub-task completes.
- DB persistence is best-effort; failures are logged at debug/warning level and do not block task execution.
- When a pinned skill is not found in the database, the system gracefully falls back to keyword-based skill selection.
- The `conversation_id` is passed through to task persistence so sub-tasks are linked to their parent conversation in the admin UI.