### PR TITLE
Fix sub-task fan-out timeouts, result loss, and UI starvation

### DIFF
--- a/src/core/concurrency.py
+++ b/src/core/concurrency.py
@@ -1,0 +1,107 @@
+"""Shared concurrency primitives for blocking LLM calls and async sub-tasks.
+
+Background
+----------
+Every LLM request in the app is a *blocking* HTTP call (the OpenAI SDK is
+synchronous) that we offload with ``asyncio.to_thread``.  ``to_thread`` uses
+the interpreter's **default** ``ThreadPoolExecutor`` whose size is only
+``min(32, cpu_count + 4)`` — 8 threads on a 4-CPU box.  That pool is shared by
+*everything* in the process.
+
+When the async sub-task feature fans out several background research loops,
+each loop holds a worker thread for the full duration of every LLM call.  A
+handful of concurrent sub-tasks can therefore occupy the entire default pool,
+and a freshly launched interactive chat has to queue for a free thread before
+its first LLM call even starts — which is exactly why "the UI doesn't load
+easily" while sub-tasks are running.
+
+This module provides two things to decouple those workloads:
+
+1. :func:`run_llm_blocking` — runs blocking LLM calls on a **dedicated**,
+   generously sized pool that is separate from the default executor, so
+   interactive requests and background work no longer compete for the same
+   8 threads.
+2. Sub-task fan-out limits — :func:`get_subtask_semaphore` bounds how many
+   background sub-tasks run at once (reserving pool headroom for interactive
+   chats), and the ``subtask_depth`` context variable bounds recursive
+   fan-out so sub-tasks dispatching sub-tasks cannot exhaust the pool.
+"""
+
+import asyncio
+import contextvars
+import functools
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Optional, TypeVar
+
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Dedicated LLM thread pool
+# ---------------------------------------------------------------------------
+# Sized well above the default min(32, cpu+4) so a burst of concurrent LLM
+# calls (interactive request + several background sub-tasks) all get a worker
+# thread immediately instead of queueing.  Override with LLM_THREAD_POOL_SIZE.
+_LLM_POOL_SIZE = max(4, int(os.getenv("LLM_THREAD_POOL_SIZE", "32")))
+
+_llm_executor = ThreadPoolExecutor(
+    max_workers=_LLM_POOL_SIZE,
+    thread_name_prefix="llm",
+)
+
+logger.info("LLM thread pool initialized with %d workers", _LLM_POOL_SIZE)
+
+
+async def run_llm_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
+    """Run a blocking LLM call on the dedicated LLM thread pool.
+
+    Drop-in replacement for ``asyncio.to_thread(func, *args, **kwargs)`` that
+    targets the dedicated pool instead of the shared default executor, keeping
+    background sub-task traffic from starving interactive requests.
+    """
+    loop = asyncio.get_running_loop()
+    call = functools.partial(func, *args, **kwargs)
+    return await loop.run_in_executor(_llm_executor, call)
+
+
+# ---------------------------------------------------------------------------
+# Sub-task fan-out limits
+# ---------------------------------------------------------------------------
+# Maximum number of dispatched sub-tasks allowed to run concurrently.  Kept
+# below the LLM pool size so there are always free threads for the interactive
+# request that spawned them.  Override with MAX_CONCURRENT_SUBTASKS.
+MAX_CONCURRENT_SUBTASKS = max(1, int(os.getenv("MAX_CONCURRENT_SUBTASKS", "6")))
+
+# Maximum recursion depth for sub-tasks dispatching further sub-tasks.
+# Depth 0 is the top-level (coordinator) request; a value of 3 allows
+# coordinator -> child -> grandchild fan-out but stops runaway recursion.
+MAX_SUBTASK_DEPTH = max(1, int(os.getenv("MAX_SUBTASK_DEPTH", "3")))
+
+# Tracks how deep in the sub-task tree the current execution is.  Because
+# ``asyncio.create_task`` copies the current context, a sub-task launched from
+# within another sub-task inherits the parent's depth automatically; the
+# dispatcher resets it to the child's own depth inside the worker coroutine.
+subtask_depth: contextvars.ContextVar[int] = contextvars.ContextVar("subtask_depth", default=0)
+
+_subtask_semaphore: Optional[asyncio.Semaphore] = None
+
+
+def get_subtask_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide sub-task concurrency semaphore.
+
+    Created lazily so it binds to the running event loop the first time a
+    sub-task is dispatched.
+    """
+    global _subtask_semaphore
+    if _subtask_semaphore is None:
+        _subtask_semaphore = asyncio.Semaphore(MAX_CONCURRENT_SUBTASKS)
+    return _subtask_semaphore
+
+
+def current_subtask_depth() -> int:
+    """Return the sub-task depth of the current execution context."""
+    return subtask_depth.get()

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -2615,7 +2615,10 @@ def define_async_task_tools():
                     "When 'skill' is omitted the sub-task performs its own automatic skill "
                     "selection based on its description. "
                     "Returns a task_id immediately. Use get_task_result to poll for completion "
-                    "and retrieve the result. Multiple tasks can run simultaneously."
+                    "and retrieve the result. Multiple tasks run concurrently (a limited number "
+                    "at a time; extras queue automatically), so dispatch all independent work up "
+                    "front and then wait. Sub-tasks may dispatch their own sub-tasks up to a "
+                    "bounded depth."
                 ),
                 parameters_model=DispatchTaskRequest,
             ),
@@ -2660,7 +2663,12 @@ def define_async_task_tools():
                     "Use this after dispatch_task instead of polling get_task_result in a loop. "
                     "You MUST call this (or get_task_result) before providing a final response "
                     "whenever you have dispatched sub-tasks — the system will not allow a final "
-                    "response while tasks are still running."
+                    "response while tasks are still running. "
+                    "A sub-task is a full agent loop and can take several minutes, so pass a "
+                    "generous timeout_seconds (default 900). Tasks reported as 'still running' "
+                    "at the timeout are NOT failed — they keep working in the background; call "
+                    "wait_for_tasks again to keep waiting, or proceed, and any late results are "
+                    "surfaced automatically on the next turn."
                 ),
                 parameters_model=WaitForTasksRequest,
             ),

--- a/src/models/plan_tools.py
+++ b/src/models/plan_tools.py
@@ -139,10 +139,14 @@ class WaitForTasksRequest(BaseModel):
         ),
     )
     timeout_seconds: int = Field(
-        default=300,
+        default=900,
         description=(
-            "Maximum seconds to wait before returning.  Tasks still running "
-            "at timeout will be reported with status 'running'."
+            "Maximum seconds to wait before returning.  A single sub-task is a "
+            "full agent loop and can take several minutes, so keep this "
+            "generous (the default is 900s / 15 min). Tasks still running at "
+            "timeout are NOT cancelled — they keep running in the background "
+            "and are reported with status 'running'; you can wait again or let "
+            "their results be surfaced automatically on a later turn."
         ),
     )
     progress_message: str = Field(

--- a/src/services/async_task_dispatcher.py
+++ b/src/services/async_task_dispatcher.py
@@ -24,8 +24,9 @@ import asyncio
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from src.core import concurrency
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -44,6 +45,13 @@ class AsyncTask:
     tools_executed: List[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None
+    # Parent conversation this sub-task belongs to — used to re-attach
+    # finished-but-uncollected results on a later turn.
+    conversation_id: str = ""
+    # True once the task's terminal result has been surfaced back to the
+    # parent conversation (either collected by wait_for_tasks/get_task_result
+    # or re-attached on a subsequent turn).  Prevents reporting it twice.
+    reported: bool = False
     # The underlying asyncio.Task — used by wait_for(); excluded from dict output.
     _asyncio_task: Optional[asyncio.Task] = field(default=None, repr=False, compare=False)
 
@@ -140,8 +148,33 @@ class AsyncTaskDispatcher:
         if context:
             message = f"Context from parent task:\n{context}\n\nTask: {description}"
 
-        task = AsyncTask(task_id=task_id, description=description, skill=skill)
+        task = AsyncTask(
+            task_id=task_id,
+            description=description,
+            skill=skill,
+            conversation_id=conversation_id or "",
+        )
         self._tasks[task_id] = task
+
+        # Fan-out depth guard: stop sub-tasks that dispatch sub-tasks from
+        # recursing without bound and exhausting the thread pool.  The current
+        # execution's depth is 0 for a top-level request; the child we're about
+        # to spawn runs one level deeper.
+        child_depth = concurrency.current_subtask_depth() + 1
+        if child_depth > concurrency.MAX_SUBTASK_DEPTH:
+            task.status = "failed"
+            task.error = (
+                f"Maximum sub-task fan-out depth ({concurrency.MAX_SUBTASK_DEPTH}) reached; "
+                "perform this work inline instead of dispatching another sub-task."
+            )
+            task.completed_at = datetime.now(timezone.utc)
+            task.reported = False
+            logger.warning(
+                f"Refused sub-task {task_id} at depth {child_depth} "
+                f"(max {concurrency.MAX_SUBTASK_DEPTH}): {description[:100]}"
+            )
+            self._persist_final(task)
+            return task_id
 
         # Persist the task record so state survives restarts and is visible
         # in the admin UI.
@@ -163,12 +196,12 @@ class AsyncTaskDispatcher:
                 logger.warning(f"Failed to persist sub-task {task_id} to DB: {exc}")
 
         asyncio_task = asyncio.create_task(
-            self._run(task, message, task_id), name=f"subtask-{task_id}"
+            self._run(task, message, task_id, child_depth), name=f"subtask-{task_id}"
         )
         task._asyncio_task = asyncio_task
 
         logger.info(
-            f"Dispatched sub-task {task_id}"
+            f"Dispatched sub-task {task_id} [depth={child_depth}]"
             + (f" [skill={skill}]" if skill else "")
             + f": {description[:100]}"
         )
@@ -178,10 +211,17 @@ class AsyncTaskDispatcher:
         """
         Return current status and (when done) result for *task_id*.
 
+        Marks the task as reported once it has reached a terminal state so it
+        is not re-surfaced by :meth:`collect_unreported`.
+
         Returns ``None`` if the task ID is unknown.
         """
         task = self._tasks.get(task_id)
-        return task.to_dict() if task else None
+        if task is None:
+            return None
+        if task.status != "running":
+            task.reported = True
+        return task.to_dict()
 
     def get_running_tasks(self) -> List[Dict[str, Any]]:
         """Return status dicts for all tasks that are still running."""
@@ -191,20 +231,60 @@ class AsyncTaskDispatcher:
         """Return status dicts for every tracked task (useful for debugging)."""
         return [t.to_dict() for t in self._tasks.values()]
 
+    def collect_unreported(self, conversation_id: str) -> List[Dict[str, Any]]:
+        """Return finished-but-unreported sub-tasks for *conversation_id*.
+
+        A sub-task outlives the wait window that the coordinator gave it (or
+        the coordinator hit its iteration budget and returned early).  Its
+        result would otherwise be stranded in the background.  Calling this at
+        the start of a new turn lets the handler surface those results instead
+        of silently dropping them.  Returned tasks are marked *reported* so
+        they are only surfaced once.
+        """
+        collected: List[Dict[str, Any]] = []
+        for task in self._tasks.values():
+            if (
+                task.conversation_id == conversation_id
+                and task.status in ("completed", "failed")
+                and not task.reported
+            ):
+                task.reported = True
+                collected.append(task.to_dict())
+        return collected
+
+    def get_running_for_conversation(self, conversation_id: str) -> List[Dict[str, Any]]:
+        """Return status dicts for running sub-tasks of *conversation_id*."""
+        return [
+            t.to_dict()
+            for t in self._tasks.values()
+            if t.conversation_id == conversation_id and t.status == "running"
+        ]
+
     async def wait_for(
         self,
         task_ids: List[str],
-        timeout: float = 300,
+        timeout: float = 900,
+        poll_interval: float = 15.0,
+        progress_callback: Optional[Callable[[Dict[str, int]], Awaitable[None]]] = None,
     ) -> Dict[str, Any]:
         """
-        Await a set of tasks and return their final status dicts.
+        Await a set of tasks and return their status dicts.
+
+        The wait polls at ``poll_interval`` so it can emit progress updates
+        (via ``progress_callback``) while long-running sub-tasks are still
+        working, rather than going silent for the whole ``timeout``.  Tasks
+        that are still running when ``timeout`` elapses are **not** cancelled —
+        they keep running in the background and can be collected later with
+        :meth:`get_status` or :meth:`collect_unreported`.
 
         Args:
             task_ids: List of task IDs to wait for.  Pass an empty list to
                 wait for *all* currently-running tasks.
-            timeout: Maximum seconds to wait before returning (tasks still
-                running at timeout will have ``status="running"`` in the
-                result dict).
+            timeout: Maximum seconds to wait before returning.  Tasks still
+                running at timeout keep ``status="running"`` in the result.
+            poll_interval: Seconds between progress checks/callbacks.
+            progress_callback: Optional async callback invoked after each poll
+                with a counts dict ``{"completed", "failed", "running"}``.
 
         Returns:
             Mapping of task_id → status dict for every requested task.
@@ -215,86 +295,127 @@ class AsyncTaskDispatcher:
         if not task_ids:
             return {}
 
-        # Gather live asyncio.Task handles for tasks that haven't finished yet
-        pending_handles = [
-            task._asyncio_task
-            for tid in task_ids
-            if (task := self._tasks.get(tid))
-            and task._asyncio_task is not None
-            and not task._asyncio_task.done()
-        ]
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
 
-        if pending_handles:
+        while True:
+            pending_handles = [
+                task._asyncio_task
+                for tid in task_ids
+                if (task := self._tasks.get(tid))
+                and task._asyncio_task is not None
+                and not task._asyncio_task.done()
+            ]
+
+            remaining = deadline - loop.time()
+            if not pending_handles or remaining <= 0:
+                break
+
             try:
-                await asyncio.wait(pending_handles, timeout=timeout)
+                await asyncio.wait(pending_handles, timeout=min(poll_interval, remaining))
             except Exception as exc:
                 logger.warning(f"wait_for encountered an error while waiting: {exc}")
+                break
 
-        return {tid: self._tasks[tid].to_dict() for tid in task_ids if tid in self._tasks}
+            # Emit a progress update if some tasks are still working.
+            if progress_callback:
+                counts = self._counts(task_ids)
+                if counts["running"]:
+                    try:
+                        await progress_callback(counts)
+                    except Exception:
+                        pass
+
+        # Mark terminal tasks as reported — the caller is collecting them now.
+        results: Dict[str, Any] = {}
+        for tid in task_ids:
+            task = self._tasks.get(tid)
+            if task is None:
+                continue
+            if task.status != "running":
+                task.reported = True
+            results[tid] = task.to_dict()
+        return results
+
+    def _counts(self, task_ids: List[str]) -> Dict[str, int]:
+        """Return completed/failed/running counts for *task_ids*."""
+        counts = {"completed": 0, "failed": 0, "running": 0}
+        for tid in task_ids:
+            task = self._tasks.get(tid)
+            if task and task.status in counts:
+                counts[task.status] += 1
+        return counts
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _run(self, task: AsyncTask, message: str, task_id: str) -> None:
-        """Execute the task and record the outcome."""
-        started_at = datetime.now(timezone.utc)
-
-        # Mark as running in DB (already created as 'running', but update
-        # started_at so the timestamp is accurate after any queue delay).
-        if self._task_repo:
-            try:
-                self._task_repo.update_task_status(
-                    task_id=task_id, status="running", started_at=started_at
-                )
-            except Exception as exc:
-                logger.debug(f"Sub-task {task_id}: failed to update started_at in DB: {exc}")
-
-        # Initialise DB-write locals before the try/except so `finally`
-        # always has valid values even if an unexpected error escapes both branches.
-        db_result: Optional[Dict[str, Any]] = None
-        db_status: str = "failed"
-        db_error: Optional[str] = None
-
+    def _persist_final(self, task: AsyncTask) -> None:
+        """Best-effort persistence of a task's terminal state to the DB."""
+        if not self._task_repo:
+            return
         try:
-            result = await self._handle_message(
-                message=message,
-                channel="subtask",
-                pinned_skill=task.skill,
+            db_result = (
+                {"response": task.result, "tools_executed": task.tools_executed}
+                if task.status == "completed"
+                else None
             )
-            task.status = "completed"
-            task.result = result.get("response", "")
-            task.tools_executed = result.get("tools_executed", [])
-            db_result = {"response": task.result, "tools_executed": task.tools_executed}
-            db_status = "completed"
-            db_error = None
+            self._task_repo.update_task_status(
+                task_id=task.task_id,
+                status=task.status,
+                completed_at=task.completed_at,
+                result=db_result,
+                error_message=task.error or None,
+            )
         except Exception as exc:
-            logger.error(
-                f"Sub-task {task.task_id} failed: {exc}",
-                exc_info=True,
-            )
-            task.status = "failed"
-            task.error = str(exc)
-            db_result = None
-            db_status = "failed"
-            db_error = str(exc)
-        finally:
-            task.completed_at = datetime.now(timezone.utc)
-            tool_count = len(task.tools_executed)
-            logger.info(
-                f"Sub-task {task.task_id} {task.status}"
-                + (f" ({tool_count} tools executed)" if tool_count else "")
-            )
+            logger.debug(f"Sub-task {task.task_id}: failed to persist final state to DB: {exc}")
 
-            # Persist final state to DB.
+    async def _run(self, task: AsyncTask, message: str, task_id: str, depth: int) -> None:
+        """Execute the task and record the outcome.
+
+        Runs under the shared sub-task semaphore so background fan-out cannot
+        occupy every LLM worker thread and starve interactive requests.  The
+        ``subtask_depth`` context variable is set to this task's own depth so
+        any further sub-tasks it dispatches are correctly depth-limited.
+        """
+        # Bound how many sub-tasks execute concurrently.  A task waiting here
+        # still reports status="running", which is accurate: it is queued.
+        async with concurrency.get_subtask_semaphore():
+            depth_token = concurrency.subtask_depth.set(depth)
+            started_at = datetime.now(timezone.utc)
+
+            # Mark started_at now that the task is actually running (it may have
+            # queued on the semaphore first).
             if self._task_repo:
                 try:
                     self._task_repo.update_task_status(
-                        task_id=task_id,
-                        status=db_status,
-                        completed_at=task.completed_at,
-                        result=db_result,
-                        error_message=db_error,
+                        task_id=task_id, status="running", started_at=started_at
                     )
                 except Exception as exc:
-                    logger.debug(f"Sub-task {task_id}: failed to persist final state to DB: {exc}")
+                    logger.debug(f"Sub-task {task_id}: failed to update started_at in DB: {exc}")
+
+            try:
+                result = await self._handle_message(
+                    message=message,
+                    channel="subtask",
+                    pinned_skill=task.skill,
+                )
+                task.status = "completed"
+                task.result = result.get("response", "")
+                task.tools_executed = result.get("tools_executed", [])
+            except Exception as exc:
+                logger.error(
+                    f"Sub-task {task.task_id} failed: {exc}",
+                    exc_info=True,
+                )
+                task.status = "failed"
+                task.error = str(exc)
+            finally:
+                task.completed_at = datetime.now(timezone.utc)
+                concurrency.subtask_depth.reset(depth_token)
+                tool_count = len(task.tools_executed)
+                logger.info(
+                    f"Sub-task {task.task_id} {task.status}"
+                    + (f" ({tool_count} tools executed)" if tool_count else "")
+                )
+                self._persist_final(task)

--- a/src/services/async_task_dispatcher.py
+++ b/src/services/async_task_dispatcher.py
@@ -323,8 +323,10 @@ class AsyncTaskDispatcher:
                 if counts["running"]:
                     try:
                         await progress_callback(counts)
-                    except Exception:
-                        pass
+                    except Exception as cb_exc:  # noqa: BLE001
+                        # Progress callbacks are best-effort; a failure must
+                        # not abort the wait or propagate to callers.
+                        logger.debug("wait_for progress_callback raised: %s", cb_exc)
 
         # Mark terminal tasks as reported — the caller is collecting them now.
         results: Dict[str, Any] = {}

--- a/src/services/message_handler.py
+++ b/src/services/message_handler.py
@@ -11,6 +11,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+from src.core.concurrency import run_llm_blocking
 from src.core.llm_client import LLMClient, LLMConfig
 from src.core.repositories.skill import SkillRepository
 from src.core.tools.executor import ToolExecutor
@@ -30,6 +31,12 @@ from src.utils.json_utils import try_repair_json
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Extra iterations granted to the coordinator purely for sub-task coordination
+# (dispatch_task / wait_for_tasks).  These tools shouldn't consume the same
+# budget as real work — otherwise the coordinator exhausts its iterations while
+# waiting on slow sub-tasks and returns before their results are collected.
+MAX_COORDINATION_ITERATIONS = 20
 
 
 class MessageHandler:
@@ -906,6 +913,37 @@ class MessageHandler:
                     )
                 messages.append({"role": "user", "content": plan_guidance})
 
+            # Re-attach any sub-tasks that finished in the background after a
+            # previous turn already returned (e.g. they outran the wait window
+            # or the coordinator hit its iteration budget). Surfacing them here
+            # means their results are never silently lost. Skipped for sub-task
+            # channels to avoid re-injecting into nested loops.
+            if channel != "subtask":
+                unreported = self.async_task_dispatcher.collect_unreported(conversation_id)
+                if unreported:
+                    lines = []
+                    for t in unreported:
+                        if t.get("status") == "completed":
+                            lines.append(
+                                f"- Sub-task {t['task_id']} ({t.get('description', '')[:80]}) "
+                                f"completed:\n{t.get('result', '')}"
+                            )
+                        else:
+                            lines.append(
+                                f"- Sub-task {t['task_id']} ({t.get('description', '')[:80]}) "
+                                f"failed: {t.get('error', '')}"
+                            )
+                    reattach_msg = (
+                        "[Background sub-tasks from an earlier turn have since finished. "
+                        "Incorporate these results if they are relevant to the user's current "
+                        "message:]\n" + "\n\n".join(lines)
+                    )
+                    messages.append({"role": "user", "content": reattach_msg})
+                    logger.info(
+                        f"Re-attached {len(unreported)} finished sub-task(s) "
+                        f"to conversation {conversation_id}"
+                    )
+
             # Log message summary for debugging
             logger.debug(
                 f"Final message list: {len(messages)} messages. "
@@ -975,14 +1013,14 @@ class MessageHandler:
             # Call LLM (with tools if available, without if none)
             logger.debug(f"Calling LLM with {len(messages)} messages and {len(tools)} tools")
             if tools:
-                response = await asyncio.to_thread(
+                response = await run_llm_blocking(
                     llm_client.complete_with_tools,
                     messages=messages,
                     tools=tools,
                     model_override=media_override,
                 )
             else:
-                response = await asyncio.to_thread(
+                response = await run_llm_blocking(
                     llm_client.complete, messages=messages, model_override=media_override
                 )
 
@@ -1034,7 +1072,7 @@ class MessageHandler:
                                 ),
                             }
                         )
-                        summary_resp = await asyncio.to_thread(
+                        summary_resp = await run_llm_blocking(
                             llm_client.complete,
                             messages=messages,
                             model_override=llm_client.config.get_worker_model(),
@@ -1149,7 +1187,7 @@ class MessageHandler:
                             ),
                         }
                     )
-                    fallback_resp = await asyncio.to_thread(
+                    fallback_resp = await run_llm_blocking(
                         llm_client.complete,
                         messages=messages,
                         model_override=llm_client.config.get_worker_model(),
@@ -1266,6 +1304,12 @@ class MessageHandler:
                     description = arguments.get("description", "")
                     context = arguments.get("context", "")
                     skill_name = arguments.get("skill") or None
+                    # Coordination shouldn't eat into the work budget (see
+                    # MAX_COORDINATION_ITERATIONS).
+                    effective_max_iterations = min(
+                        effective_max_iterations + 1,
+                        self.max_iterations + MAX_COORDINATION_ITERATIONS,
+                    )
                     logger.info(
                         f"dispatch_task called: {description[:100]}"
                         + (f" [skill={skill_name}]" if skill_name else "")
@@ -1329,10 +1373,18 @@ class MessageHandler:
                 # ----------------------------------------------------------
                 if tool_name == "wait_for_tasks":
                     requested_ids = arguments.get("task_ids") or []
-                    timeout = float(arguments.get("timeout_seconds", 300))
+                    timeout = float(arguments.get("timeout_seconds", 900))
                     progress_message = arguments.get(
                         "progress_message",
                         "Working on background tasks, please wait…",
+                    )
+
+                    # Coordinating sub-tasks shouldn't burn the main iteration
+                    # budget — otherwise the coordinator runs out of iterations
+                    # while waiting and returns before slow tasks are collected.
+                    effective_max_iterations = min(
+                        effective_max_iterations + 1,
+                        self.max_iterations + MAX_COORDINATION_ITERATIONS,
                     )
 
                     # Determine which tasks we're waiting for
@@ -1343,7 +1395,7 @@ class MessageHandler:
 
                     logger.info(
                         f"wait_for_tasks: waiting for {len(requested_ids)} task(s): "
-                        f"{requested_ids}"
+                        f"{requested_ids} (timeout={timeout}s)"
                     )
 
                     # Notify the originating channel that work is in progress.
@@ -1355,10 +1407,36 @@ class MessageHandler:
                             message=f"⏳ {progress_message}",
                         )
 
-                    # Block until all requested tasks finish (or timeout)
+                    # Emit periodic progress while long-running tasks work, so
+                    # the wait doesn't go silent for minutes at a time.
+                    async def _wait_progress(counts: Dict[str, int]) -> None:
+                        done = counts["completed"] + counts["failed"]
+                        total = done + counts["running"]
+                        await self._emit(
+                            event_callback,
+                            {
+                                "type": "subtask_progress",
+                                "completed": counts["completed"],
+                                "failed": counts["failed"],
+                                "running": counts["running"],
+                            },
+                        )
+                        if done:
+                            await self._send_progress_notification(
+                                channel=channel,
+                                contact_identifier=contact_identifier,
+                                message=f"⏳ Sub-tasks: {done}/{total} finished, "
+                                f"{counts['running']} still working…",
+                            )
+
+                    # Block until all requested tasks finish (or timeout). Tasks
+                    # still running at timeout are NOT cancelled — they keep
+                    # going and are collected later via get_task_result or
+                    # re-attached automatically on the next turn.
                     results = await self.async_task_dispatcher.wait_for(
                         task_ids=requested_ids,
                         timeout=timeout,
+                        progress_callback=_wait_progress if requested_ids else None,
                     )
 
                     # Build completion summary and notify channel
@@ -1369,8 +1447,10 @@ class MessageHandler:
                     if failed:
                         parts.append(f"{failed} failed")
                     if still_running:
-                        parts.append(f"{still_running} timed out")
-                    summary = "✅ Sub-tasks done: " + ", ".join(parts)
+                        # These are NOT dead — they exceeded the wait window and
+                        # keep running in the background.
+                        parts.append(f"{still_running} still running in background")
+                    summary = "✅ Sub-tasks: " + ", ".join(parts)
 
                     if requested_ids:
                         await self._send_progress_notification(
@@ -1379,11 +1459,23 @@ class MessageHandler:
                             message=summary,
                         )
 
+                    guidance = ""
+                    if still_running:
+                        guidance = (
+                            " Sub-tasks still running are NOT failed — they are continuing in "
+                            "the background. Either call wait_for_tasks again (optionally with a "
+                            "larger timeout_seconds) to keep waiting, or proceed with the results "
+                            "you have; the remaining results will be surfaced automatically once "
+                            "they finish."
+                        )
+
                     tool_results.append(
                         {
                             "role": "tool",
                             "tool_call_id": tool_call_id,
-                            "content": json.dumps({"tasks": results, "summary": summary}),
+                            "content": json.dumps(
+                                {"tasks": results, "summary": summary + guidance}
+                            ),
                         }
                     )
                     tools_executed.append(tool_name)
@@ -1570,7 +1662,7 @@ class MessageHandler:
                 )
 
                 # Get final response without tools
-                final_response_obj = await asyncio.to_thread(
+                final_response_obj = await run_llm_blocking(
                     llm_client.complete,
                     messages=messages,
                     model_override=llm_client.config.get_worker_model(),
@@ -1605,7 +1697,7 @@ class MessageHandler:
             }
         )
 
-        final_response_obj = await asyncio.to_thread(
+        final_response_obj = await run_llm_blocking(
             llm_client.complete,
             messages=messages,
             model_override=llm_client.config.get_worker_model(),
@@ -1692,7 +1784,7 @@ class MessageHandler:
         ]
 
         try:
-            resp = await asyncio.to_thread(
+            resp = await run_llm_blocking(
                 llm_client.complete,
                 messages=validation_messages,
                 model_override=llm_client.config.get_worker_model(),

--- a/tests/test_async_task_dispatcher.py
+++ b/tests/test_async_task_dispatcher.py
@@ -1,0 +1,122 @@
+"""Tests for AsyncTaskDispatcher fan-out safety and result collection.
+
+These cover the behaviour added to fix sub-tasks appearing to "time out and
+die": concurrency capping, fan-out depth limiting, non-cancelling waits, and
+re-attachment of finished-but-uncollected results.
+
+The dispatcher only depends on stdlib + src.core.concurrency, so these tests
+run without the full app stack.
+"""
+
+import asyncio
+
+import pytest
+
+from src.core import concurrency
+from src.services.async_task_dispatcher import AsyncTaskDispatcher
+
+
+@pytest.mark.asyncio
+async def test_waited_tasks_complete_and_report_results():
+    async def handler(message, channel="subtask", pinned_skill=None):
+        await asyncio.sleep(0.01)
+        return {"response": f"done:{message}", "tools_executed": ["t"]}
+
+    d = AsyncTaskDispatcher(handler)
+    ids = [d.dispatch(f"task-{i}", conversation_id="conv1") for i in range(3)]
+
+    results = await d.wait_for(ids, timeout=5)
+
+    assert len(results) == 3
+    assert all(r["status"] == "completed" for r in results.values())
+    assert all("done:" in r["result"] for r in results.values())
+
+
+@pytest.mark.asyncio
+async def test_slow_task_reported_running_not_cancelled():
+    """A task that outruns the wait window stays 'running' and keeps going."""
+    started = asyncio.Event()
+
+    async def slow_handler(message, channel="subtask", pinned_skill=None):
+        started.set()
+        await asyncio.sleep(0.3)
+        return {"response": "late", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(slow_handler)
+    tid = d.dispatch("slow", conversation_id="conv1")
+    await started.wait()
+
+    # Wait far less than the task takes.
+    results = await d.wait_for([tid], timeout=0.05, poll_interval=0.02)
+    assert results[tid]["status"] == "running"
+
+    # It was NOT cancelled — it finishes on its own and is then collectable.
+    assert d._tasks[tid]._asyncio_task is not None
+    await d._tasks[tid]._asyncio_task
+    assert d.get_status(tid)["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_concurrency_cap_limits_simultaneous_tasks(monkeypatch):
+    """No more than MAX_CONCURRENT_SUBTASKS run at once."""
+    # Force a small cap and a fresh semaphore bound to this loop.
+    monkeypatch.setattr(concurrency, "MAX_CONCURRENT_SUBTASKS", 2)
+    monkeypatch.setattr(concurrency, "_subtask_semaphore", None)
+
+    active = 0
+    peak = 0
+
+    async def handler(message, channel="subtask", pinned_skill=None):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return {"response": "ok", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(handler)
+    ids = [d.dispatch(f"t{i}", conversation_id="c") for i in range(6)]
+    await d.wait_for(ids, timeout=5)
+
+    assert peak <= 2, f"peak concurrency {peak} exceeded cap"
+
+
+@pytest.mark.asyncio
+async def test_fanout_depth_limit(monkeypatch):
+    """A sub-task cannot dispatch beyond MAX_SUBTASK_DEPTH."""
+    monkeypatch.setattr(concurrency, "MAX_SUBTASK_DEPTH", 1)
+    monkeypatch.setattr(concurrency, "_subtask_semaphore", None)
+
+    d = AsyncTaskDispatcher(None)  # handler unused; we call dispatch directly
+
+    # Simulate running inside a depth-1 sub-task: dispatching would create a
+    # depth-2 child, which exceeds the max.
+    token = concurrency.subtask_depth.set(1)
+    try:
+        tid = d.dispatch("too deep", conversation_id="c")
+    finally:
+        concurrency.subtask_depth.reset(token)
+
+    status = d.get_status(tid)
+    assert status["status"] == "failed"
+    assert "depth" in status["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_collect_unreported_surfaces_finished_tasks():
+    async def handler(message, channel="subtask", pinned_skill=None):
+        await asyncio.sleep(0.01)
+        return {"response": "res", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(handler)
+    tid = d.dispatch("bg", conversation_id="conv-x")
+    await d._tasks[tid]._asyncio_task  # let it finish without a wait_for call
+
+    unreported = d.collect_unreported("conv-x")
+    assert len(unreported) == 1
+    assert unreported[0]["task_id"] == tid
+
+    # Only surfaced once.
+    assert d.collect_unreported("conv-x") == []
+    # Different conversation sees nothing.
+    assert d.collect_unreported("other") == []


### PR DESCRIPTION
The async sub-task feature (v1.3.4) made several concurrent sub-tasks
appear to "time out and die" while only the first survived, and made
newly launched chats slow to load. Root causes:

- The wait window (300s) was far shorter than a real sub-task (a full
  agent loop, often several minutes), so most were reported "timed out"
  — misleading, since they were never cancelled and kept running.
- Coordination tools (dispatch_task/wait_for_tasks) consumed the same
  iteration budget as real work, so the coordinator ran out of
  iterations and returned before slow sub-tasks were collected, leaving
  their results stranded.
- All blocking LLM calls shared the interpreter's small default thread
  pool (min(32, cpu+4)). Background fan-out saturated it, so an
  interactive chat had to queue for a worker thread before its first
  LLM call — "the UI doesn't load easily."
- Fan-out was unbounded (sub-tasks could dispatch sub-tasks with no
  depth or concurrency limit), amplifying the pressure.

Changes:
- Add src/core/concurrency.py: a dedicated, generously sized thread
  pool for LLM calls (run_llm_blocking) so interactive requests never
  queue behind background work; plus a sub-task concurrency semaphore
  and a fan-out depth contextvar. All tunable via env.
- Route every llm_client.complete* call in message_handler through the
  dedicated pool.
- Dispatcher: cap concurrent sub-tasks, limit fan-out depth, and make
  wait_for poll with a progress callback instead of a single silent
  deadline; tasks still running at timeout are left running, not
  cancelled.
- Re-attach: finished-but-uncollected sub-task results are surfaced on
  the next turn (collect_unreported) so nothing is silently lost.
- Stop coordination tools from exhausting the iteration budget.
- Report still-running tasks as "still running in background" (not
  "timed out"), with guidance to the model; raise default wait timeout
  to 900s and update tool descriptions.
- Add tests/test_async_task_dispatcher.py covering concurrency cap,
  depth limit, non-cancelling waits, and re-attach.