### PR TITLE
Add Model Context Protocol (MCP) server integration

### DIFF
--- a/src/models/mcp.py
+++ b/src/models/mcp.py
@@ -83,6 +83,9 @@ class McpServerConfig(BaseModel):
 
     # Intent keywords copied onto the generated agent/skill row for triggering.
     intent_keywords: List[str] = Field(default_factory=list)
+    # Optional system-prompt text injected when this server's tools are active.
+    # When empty the service generates a default backstory.
+    backstory: Optional[str] = None
     # Cached tool schemas from the last successful discovery, so startup can
     # register tools without contacting every server.
     discovered_tools: List[McpDiscoveredTool] = Field(default_factory=list)
@@ -149,6 +152,7 @@ class McpServerCreateRequest(BaseModel):
     auth_headers: List[McpAuthHeaderInput] = Field(default_factory=list)
     oauth_scopes: List[str] = Field(default_factory=list)
     intent_keywords: List[str] = Field(default_factory=list)
+    backstory: Optional[str] = Field(default=None, max_length=2000)
 
 
 class McpCredentialsRequest(BaseModel):
@@ -194,6 +198,7 @@ class McpServerListItem(BaseModel):
     enabled: bool
     has_credentials: bool
     intent_keywords: List[str] = Field(default_factory=list)
+    backstory: Optional[str] = None
     tool_count: int = 0
     tool_names: List[str] = Field(default_factory=list)
 
@@ -201,13 +206,14 @@ class McpServerListItem(BaseModel):
 class McpServerUpdateRequest(BaseModel):
     """Request to update mutable fields of an existing MCP server.
 
-    Only ``display_name`` and ``intent_keywords`` may be changed here.
-    To change auth headers use ``/credentials``; to re-discover tools use
-    ``/refresh``; to change enable state use ``/enable``.
+    Only ``display_name``, ``intent_keywords``, and ``backstory`` may be
+    changed here. To change auth headers use ``/credentials``; to re-discover
+    tools use ``/refresh``; to change enable state use ``/enable``.
     """
 
     display_name: Optional[str] = Field(None, min_length=1, max_length=100)
     intent_keywords: Optional[List[str]] = None
+    backstory: Optional[str] = Field(default=None, max_length=2000)
 
 
 class McpTestResult(BaseModel):

--- a/src/services/mcp_service.py
+++ b/src/services/mcp_service.py
@@ -672,6 +672,7 @@ class McpService(BaseService):
                     enabled=self._is_enabled(server_id),
                     has_credentials=bool(self.credentials_repo.get(f"mcp_{server_id}")),
                     intent_keywords=cfg.intent_keywords,
+                    backstory=cfg.backstory,
                     tool_count=len(cfg.discovered_tools),
                     tool_names=[t.name for t in cfg.discovered_tools],
                 )
@@ -705,6 +706,7 @@ class McpService(BaseService):
             auth_headers=[{"name": h.name} for h in request.auth_headers],
             oauth_scopes=request.oauth_scopes,
             intent_keywords=[k.strip() for k in request.intent_keywords if k.strip()],
+            backstory=request.backstory or None,
         )
 
         if request.auth_type == "oauth2":
@@ -763,6 +765,8 @@ class McpService(BaseService):
             data["display_name"] = request.display_name
         if request.intent_keywords is not None:
             data["intent_keywords"] = [k.strip() for k in request.intent_keywords if k.strip()]
+        if request.backstory is not None:
+            data["backstory"] = request.backstory.strip() or None
 
         cfg = McpServerConfig.model_validate(data)
         self._configs[server_id] = cfg
@@ -848,7 +852,7 @@ class McpService(BaseService):
         tool_names = [f"mcp_{cfg.id}_{t.name}" for t in cfg.discovered_tools]
         role = f"{cfg.display_name} (MCP server)"
         goal = cfg.description or f"Use the {cfg.display_name} MCP server's tools."
-        backstory = (
+        backstory = cfg.backstory or (
             f"You have access to the '{cfg.display_name}' MCP server. "
             f"Use its tools to fulfil requests related to it."
         )

--- a/src/ui/static/js/settings.js
+++ b/src/ui/static/js/settings.js
@@ -2628,6 +2628,7 @@ async function createMcpServer() {
     const keywords = document.getElementById('new-mcp-keywords').value
         .split(',').map(k => k.trim()).filter(Boolean);
 
+    const backstory = document.getElementById('new-mcp-backstory').value.trim();
     const body = {
         id,
         display_name: displayName,
@@ -2635,6 +2636,7 @@ async function createMcpServer() {
         url,
         auth_type: authType,
         intent_keywords: keywords,
+        ...(backstory ? { backstory } : {}),
     };
 
     if (authType === 'header') {
@@ -2719,6 +2721,7 @@ function openMcpEditModal(serverId) {
     document.getElementById('mcp-edit-server-id').value = serverId;
     document.getElementById('mcp-edit-display-name').value = srv.display_name || '';
     document.getElementById('mcp-edit-keywords').value = (srv.intent_keywords || []).join(', ');
+    document.getElementById('mcp-edit-backstory').value = srv.backstory || '';
     document.getElementById('mcpEditModal').style.display = 'flex';
 }
 
@@ -2731,10 +2734,12 @@ async function saveMcpEdit() {
     const displayName = document.getElementById('mcp-edit-display-name').value.trim();
     const keywords = document.getElementById('mcp-edit-keywords').value
         .split(',').map(k => k.trim()).filter(k => k);
+    const backstory = document.getElementById('mcp-edit-backstory').value.trim();
 
     const body = {};
     if (displayName) body.display_name = displayName;
     body.intent_keywords = keywords;
+    body.backstory = backstory || null;
 
     try {
         await api.patch(`/api/mcp/${serverId}`, body);

--- a/src/ui/static/settings.html
+++ b/src/ui/static/settings.html
@@ -486,6 +486,10 @@
                     <input type="text" id="new-mcp-keywords" class="form-input" placeholder="cloudflare, gateway, cdn">
                     <div class="form-hint">A message containing any of these words activates this server's tools.</div>
                 </div>
+                <div class="form-group">
+                    <label for="new-mcp-backstory">Backstory <span class="text-muted">(optional)</span></label>
+                    <textarea id="new-mcp-backstory" class="form-input" rows="3" maxlength="2000" placeholder="Custom system-prompt text injected when this server is active. Leave blank for the default."></textarea>
+                </div>
 
                 <!-- Server URL -->
                 <div class="form-group">
@@ -564,7 +568,7 @@
         </div>
     </div>
 
-    <!-- Edit MCP Server Modal (display_name + intent_keywords) -->
+    <!-- Edit MCP Server Modal (display_name + intent_keywords + backstory) -->
     <div id="mcpEditModal" class="modal" style="display: none;">
         <div class="modal-content" style="max-width:480px;">
             <div class="modal-header">
@@ -581,6 +585,10 @@
                     <label for="mcp-edit-keywords">Intent Keywords <span class="text-muted">(comma-separated)</span></label>
                     <input type="text" id="mcp-edit-keywords" class="form-input" placeholder="email, send, compose">
                     <small class="text-muted">A message containing any of these words activates this server's tools.</small>
+                </div>
+                <div class="form-group">
+                    <label for="mcp-edit-backstory">Backstory <span class="text-muted">(optional)</span></label>
+                    <textarea id="mcp-edit-backstory" class="form-input" rows="3" maxlength="2000" placeholder="Custom system-prompt text injected when this server is active. Leave blank for the default."></textarea>
                 </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
## Summary
Adds comprehensive support for integrating Model Context Protocol (MCP) servers as a new skill type. MCP servers are configured via the UI, their tools are automatically discovered and registered, and they participate in the agent selection pipeline just like regular skills.

## Key Changes

### Backend Services
- **`src/services/mcp_service.py`** (new): Core MCP integration service that:
  - Manages MCP server configurations persisted as `data/mcp_servers/{id}.json`
  - Discovers tools via JSON-RPC 2.0 HTTP requests to MCP servers
  - Registers discovered tools in the global tool registry with proper naming (`mcp_{server_id}_{tool_name}`)
  - Executes tool calls by routing through the MCP server's `tools/call` endpoint
  - Syncs agent/skill rows in `agent_definitions` for intent-based skill selection
  - Supports static-header authentication with encrypted credential storage
  - Provides CRUD operations, connectivity testing, and tool refresh

### API Endpoints
- **`src/api/mcp.py`** (new): REST API routes for:
  - `GET /api/mcp` — List all configured servers
  - `POST /api/mcp` — Add a new server (connects, discovers tools, creates skill row)
  - `PATCH /api/mcp/{server_id}` — Update display name, intent keywords, backstory
  - `PUT /api/mcp/{server_id}/enable` — Enable/disable a server and its skill
  - `PUT /api/mcp/{server_id}/credentials` — Update auth header values
  - `POST /api/mcp/{server_id}/refresh` — Re-discover tools
  - `GET /api/mcp/{server_id}/test` — Test connectivity
  - `DELETE /api/mcp/{server_id}` — Delete server, tools, credentials, and skill row

### Data Models
- **`src/models/mcp.py`** (new): Pydantic models for:
  - `McpServerConfig` — Complete server definition with validation
  - `McpDiscoveredTool` — Tool schema from MCP discovery
  - Request/response models for all API operations
  - `McpTestResult` — Connectivity test results

### UI Components
- **`src/ui/static/settings.html`** (modified): Added "MCP Servers" tab with:
  - Server list with tool counts and status indicators
  - Add/Edit/Delete modals for server management
  - Authentication header configuration UI
  - Intent keywords and backstory editors
  - Test, refresh, enable/disable buttons

- **`src/ui/static/js/settings.js`** (modified): Added MCP management functions:
  - Lazy-loading of MCP servers tab
  - Server card rendering with action buttons
  - Modal dialogs for add/edit operations
  - API integration for all CRUD operations

### Integration Points
- **`src/core/tools/executor.py`** (modified): Routes MCP tool execution through `McpService.execute_tool()`
- **`src/main.py`** (modified): Initializes `McpService` at startup and registers cached tool schemas
- **`src/ui/static/js/common.js`** (modified): Added `patch()` method to API client for PATCH requests

## Notable Implementation Details

- **Skill Integration**: Each MCP server automatically gets an agent/skill row in `agent_definitions`, allowing it to participate in intent-based selection via keywords and backstory injection
- **Tool Naming**: Tools are namespaced as `mcp_{server_id}_{tool_name}` to avoid collisions
- **Authentication**: Supports static header authentication with encrypted credential storage separate from server config
- **Graceful Degradation**: Disabled servers are excluded from tool registration and skill selection
- **Atomic Operations**: Server addition fails cleanly if tool discovery fails — no partial state
- **Backstory System**: Servers can have custom backstories injected into the LLM system prompt, or use auto-generated ones