### PR TITLE
Add deduplication for identical tool calls within a time window

### DIFF
--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -1,7 +1,9 @@
 """Tool executor for routing LLM tool calls to service methods."""
 
+import hashlib
+import json
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from src.core.tools.registry import get_tool_registry
 from src.models.nextcloud import UploadFileRequest as NextcloudUploadFileRequest
@@ -32,6 +34,9 @@ except ImportError:
 
 class ToolExecutor:
     """Executes tool calls from LLM."""
+
+    # Seconds within which an identical (tool, args) call is considered a duplicate.
+    _DEDUP_WINDOW = 30.0
 
     def __init__(
         self,
@@ -103,10 +108,19 @@ class ToolExecutor:
         self.audit_repo = audit_repo
         self.conversation_id = conversation_id
 
+        # Per-request dedup cache: maps key → (timestamp, cached_result)
+        self._dedup_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
         # Debug logging
         logger.info(
             f"ToolExecutor initialized with audit_repo={audit_repo is not None}, conversation_id={conversation_id}"
         )
+
+    @staticmethod
+    def _make_dedup_key(tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Return a short stable hash identifying a specific (tool, args) call."""
+        payload = f"{tool_name}:{json.dumps(arguments, sort_keys=True)}"
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
     async def execute_tool(
         self,
@@ -149,6 +163,26 @@ class ToolExecutor:
             )
             return error_result
 
+        # Dedup check — same (tool, args) within _DEDUP_WINDOW seconds returns cached result
+        dedup_key = self._make_dedup_key(tool_name, arguments)
+        cached = self._dedup_cache.get(dedup_key)
+        if cached is not None:
+            cached_at, cached_result = cached
+            age_s = time.time() - cached_at
+            if age_s < self._DEDUP_WINDOW:
+                logger.info(
+                    "Dedup: skipping duplicate '%s' call (already ran %.0fs ago)",
+                    tool_name,
+                    age_s,
+                )
+                return {
+                    **cached_result,
+                    "note": (
+                        f"This {tool_name} call was already executed {int(age_s)}s ago "
+                        "and returned the same result — no action taken."
+                    ),
+                }
+
         # Route plugin tools directly through PluginService
         if tool.service_name.startswith("plugin_") and self.plugin_service:
             try:
@@ -165,6 +199,7 @@ class ToolExecutor:
                     tool_call_id=tool_call_id,
                     iteration=iteration,
                 )
+                self._dedup_cache[dedup_key] = (time.time(), success_result)
                 return success_result
             except Exception as e:
                 execution_time_ms = int((time.time() - start_time) * 1000)
@@ -199,6 +234,7 @@ class ToolExecutor:
                     tool_call_id=tool_call_id,
                     iteration=iteration,
                 )
+                self._dedup_cache[dedup_key] = (time.time(), success_result)
                 return success_result
             except Exception as e:
                 execution_time_ms = int((time.time() - start_time) * 1000)
@@ -258,6 +294,7 @@ class ToolExecutor:
                 iteration=iteration,
             )
 
+            self._dedup_cache[dedup_key] = (time.time(), success_result)
             return success_result
         except Exception as e:
             execution_time_ms = int((time.time() - start_time) * 1000)

--- a/tests/test_dedup_tool_calls.py
+++ b/tests/test_dedup_tool_calls.py
@@ -1,0 +1,188 @@
+"""Tests for duplicate tool-call suppression in ToolExecutor."""
+
+import time
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.tools.executor import ToolExecutor
+
+
+def _make_executor() -> ToolExecutor:
+    """Return a minimal ToolExecutor with a fake registry and a non-None system service."""
+    executor = ToolExecutor()
+    fake_tool = MagicMock()
+    fake_tool.service_name = "system"
+    executor.registry = MagicMock()
+    executor.registry.get.return_value = fake_tool
+    executor.services["system"] = MagicMock()  # avoids "service not available" early-return
+    return executor
+
+
+@pytest.fixture
+def executor():
+    return _make_executor()
+
+
+class TestMakeDedupKey:
+    def test_same_tool_same_args_same_key(self):
+        k1 = ToolExecutor._make_dedup_key("my_tool", {"a": 1, "b": 2})
+        k2 = ToolExecutor._make_dedup_key("my_tool", {"b": 2, "a": 1})
+        assert k1 == k2, "arg order must not affect the key"
+
+    def test_different_tool_different_key(self):
+        k1 = ToolExecutor._make_dedup_key("tool_a", {"x": 1})
+        k2 = ToolExecutor._make_dedup_key("tool_b", {"x": 1})
+        assert k1 != k2
+
+    def test_different_args_different_key(self):
+        k1 = ToolExecutor._make_dedup_key("tool", {"v": 1})
+        k2 = ToolExecutor._make_dedup_key("tool", {"v": 2})
+        assert k1 != k2
+
+    def test_key_is_short_string(self):
+        k = ToolExecutor._make_dedup_key("t", {})
+        assert isinstance(k, str) and len(k) == 16
+
+
+class TestDedupCacheHit:
+    @pytest.mark.asyncio
+    async def test_second_identical_call_is_blocked(self, executor):
+        """Second call within the window returns cached result + note, skips execution."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            return {"data": "ok"}
+
+        executor._route_tool_call = fake_route
+
+        args = {"query": "hello"}
+
+        r1 = await executor.execute_tool("search_web", args)
+        r2 = await executor.execute_tool("search_web", args)
+
+        assert call_count == 1, "service should only be called once"
+        assert r1["success"] is True
+        assert r2["success"] is True
+        assert "note" in r2, "blocked duplicate must carry a note"
+        assert "already executed" in r2["note"]
+        assert r2["result"] == r1["result"]
+
+    @pytest.mark.asyncio
+    async def test_note_is_absent_on_first_call(self, executor):
+        async def fake_route(tool_name, service, arguments):
+            return {"data": "ok"}
+
+        executor._route_tool_call = fake_route
+
+        r1 = await executor.execute_tool("search_web", {"q": "hi"})
+        assert "note" not in r1
+
+    @pytest.mark.asyncio
+    async def test_different_args_not_blocked(self, executor):
+        """Same tool with different args must execute both times."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            return {"data": arguments.get("q")}
+
+        executor._route_tool_call = fake_route
+
+        await executor.execute_tool("search_web", {"q": "foo"})
+        await executor.execute_tool("search_web", {"q": "bar"})
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_different_tools_not_blocked(self, executor):
+        """Different tools with same args must both execute."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            return {}
+
+        executor._route_tool_call = fake_route
+
+        await executor.execute_tool("tool_a", {"x": 1})
+        await executor.execute_tool("tool_b", {"x": 1})
+
+        assert call_count == 2
+
+
+class TestDedupWindowExpiry:
+    @pytest.mark.asyncio
+    async def test_call_allowed_after_window_expires(self, executor):
+        """After the TTL window, the same call must go through again."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            return {}
+
+        executor._route_tool_call = fake_route
+
+        await executor.execute_tool("some_tool", {"k": "v"})
+        assert call_count == 1
+
+        # Backdate the cache entry to simulate expiry
+        key = ToolExecutor._make_dedup_key("some_tool", {"k": "v"})
+        cached_at, cached_result = executor._dedup_cache[key]
+        executor._dedup_cache[key] = (cached_at - ToolExecutor._DEDUP_WINDOW - 1, cached_result)
+
+        await executor.execute_tool("some_tool", {"k": "v"})
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_call_blocked_within_window(self, executor):
+        """Call just inside the window boundary is still blocked."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            return {}
+
+        executor._route_tool_call = fake_route
+
+        await executor.execute_tool("some_tool", {"k": "v"})
+
+        # Backdate to 1s before expiry — should still be blocked
+        key = ToolExecutor._make_dedup_key("some_tool", {"k": "v"})
+        cached_at, cached_result = executor._dedup_cache[key]
+        executor._dedup_cache[key] = (
+            cached_at - ToolExecutor._DEDUP_WINDOW + 1,
+            cached_result,
+        )
+
+        await executor.execute_tool("some_tool", {"k": "v"})
+        assert call_count == 1
+
+
+class TestDedupOnlyForSuccess:
+    @pytest.mark.asyncio
+    async def test_error_result_not_cached(self, executor):
+        """Failed tool calls must not populate the dedup cache."""
+        call_count = 0
+
+        async def fake_route(tool_name, service, arguments):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("network error")
+
+        executor._route_tool_call = fake_route
+        executor.audit_repo = None
+
+        r1 = await executor.execute_tool("flaky_tool", {"x": 1})
+        r2 = await executor.execute_tool("flaky_tool", {"x": 1})
+
+        assert call_count == 2, "errors must not be deduped"
+        assert r1["success"] is False
+        assert r2["success"] is False

--- a/tests/test_dedup_tool_calls.py
+++ b/tests/test_dedup_tool_calls.py
@@ -1,8 +1,6 @@
 """Tests for duplicate tool-call suppression in ToolExecutor."""
 
-import time
-from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_usage_recorder.py
+++ b/tests/test_usage_recorder.py
@@ -347,8 +347,11 @@ def compaction_db(test_db_path):
             "token_count, timestamp) VALUES (?,?,?,?,?,?)",
             (f"{cid}-new", cid, "assistant", "recent", 50, recent),
         )
-    om = (datetime.utcnow() - timedelta(days=120)).strftime("%Y-%m-%d %H:%M:%S")
-    om2 = (datetime.utcnow() - timedelta(days=100)).strftime("%Y-%m-%d %H:%M:%S")
+    # Use fixed months in the past so they're always >90 days old AND in
+    # different calendar months (the day-delta approach is date-sensitive and
+    # can land both timestamps in the same month depending on when the test runs).
+    om = "2024-01-15 12:00:00"
+    om2 = "2024-03-15 12:00:00"
     rt = (datetime.utcnow() - timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
     for _ in range(4):
         conn.execute(


### PR DESCRIPTION
## Summary
This PR adds duplicate tool-call suppression to the `ToolExecutor` class. When the same tool is called with identical arguments within a 30-second window, the cached result is returned instead of re-executing the tool. This prevents redundant API calls and improves performance when LLMs make repeated identical requests.

## Key Changes
- **Deduplication cache**: Added `_dedup_cache` dictionary to store recent successful tool call results with timestamps
- **Cache key generation**: Implemented `_make_dedup_key()` static method that creates a stable 16-character hash from tool name and arguments (order-independent)
- **Dedup window**: Defined `_DEDUP_WINDOW = 30.0` seconds as the TTL for cached results
- **Dedup check logic**: Before executing a tool, check if an identical call exists in cache and is still within the time window
- **Cached result return**: Duplicate calls return the cached result with an informational note explaining the call was already executed
- **Success-only caching**: Only successful tool executions are cached; failed calls are not deduplicated
- **Cache population**: All three execution paths (plugin tools, service tools, and generic routing) populate the cache on success

## Implementation Details
- The dedup key is computed from `tool_name` and `arguments` using SHA256 hashing (truncated to 16 chars) with sorted JSON serialization to ensure argument order doesn't affect the key
- Cache entries store both the timestamp and the complete result object for quick retrieval
- The dedup check happens early in `execute_tool()` after basic validation but before any service calls
- Duplicate calls include a descriptive note in the response indicating when the original call was made
- Comprehensive test coverage validates key generation, cache hits/misses, window expiry, and error handling