### PR TITLE
Update MCP client to support mcp>=2.0.0 API changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "scipy>=1.12.0",
     "kaleido>=0.2.1",
     "jinja2>=3.1.0",
-    "mcp>=1.2.0",
+    "mcp>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-assistant"
-version = "1.3.7"
+version = "1.3.8"
 description = "AI-powered personal assistant for task automation and integration"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/services/mcp_service.py
+++ b/src/services/mcp_service.py
@@ -511,8 +511,9 @@ class McpService(BaseService):
     ) -> Any:
         """Open a short-lived Streamable-HTTP session and run ``fn(session)``."""
         try:
+            import httpx2
             from mcp import ClientSession
-            from mcp.client.streamable_http import streamablehttp_client
+            from mcp.client.streamable_http import streamable_http_client
         except ImportError as e:  # pragma: no cover - depends on optional dep
             raise McpSdkNotInstalled(
                 "The 'mcp' Python SDK is not installed. Install it (pip install mcp) "
@@ -526,10 +527,12 @@ class McpService(BaseService):
         headers = self._build_request_headers(cfg)
 
         async def _do() -> Any:
-            async with streamablehttp_client(cfg.url, headers=headers or None) as (
+            # mcp >=2.0: headers are passed via a pre-built httpx2.AsyncClient;
+            # the context manager now yields a 2-tuple (read, write).
+            http_client = httpx2.AsyncClient(headers=headers) if headers else None
+            async with streamable_http_client(cfg.url, http_client=http_client) as (
                 read,
                 write,
-                _,
             ):
                 async with ClientSession(read, write) as session:
                     await session.initialize()


### PR DESCRIPTION
## Summary
Updates the MCP service to be compatible with mcp>=2.0.0, which introduced breaking changes to the streamable HTTP client API.

## Key Changes
- Updated import from `streamablehttp_client` to `streamable_http_client` (function name change)
- Modified `streamable_http_client` invocation to use the new `http_client` parameter that accepts a pre-built `httpx2.AsyncClient` instance
- Removed the third element from the context manager tuple unpacking (previously `_`), as mcp 2.0 now yields only a 2-tuple `(read, write)` instead of 3 elements
- Added `import httpx2` to support creating the AsyncClient with custom headers
- Updated minimum mcp dependency version from `>=1.2.0` to `>=2.0.0`

## Implementation Details
The mcp 2.0 API change shifts header management from the `streamable_http_client` function parameters to the underlying HTTP client. Headers are now passed by creating an `httpx2.AsyncClient` instance with the desired headers and passing it via the `http_client` parameter. The context manager signature also changed to return only the read/write streams without an additional element.