### PR TITLE
Add documentation for `/clear` slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This personal assistant bot provides a unified interface to interact with your p
 - **History**: Full conversation persistence with search and date filtering
 - **Memory**: Smart context management with automatic summarization
 - **Features**: Pin conversations, auto-generate titles, conversation statistics
+- **`/clear` command**: Start a fresh conversation thread when switching topics — keeps threads focused and responses sharp. Past conversations remain searchable; `memory_recall` and conversation search bridge context across threads when needed. See [Commands](docs/commands.md).
 
 ### Personalization
 - **System Prompt**: Default base prompt with customizable instructions on top

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,35 @@
+# Commands
+
+Open Assistant supports a small set of slash commands you can type directly in any conversation.
+
+## `/clear`
+
+Start a fresh conversation thread.
+
+```
+/clear
+```
+
+**Response**: `Conversation cleared.`
+
+### Why use it
+
+Open Assistant keeps the full message history of the current conversation in context when forming its responses. This is great for continuity within a single topic, but it becomes a liability once the conversation drifts:
+
+- **Mixed topics confuse the model.** If you ask about your calendar, then pivot to drafting an email, then ask something unrelated, the model has to reason over a noisy, multi-topic thread. Responses become less focused and more likely to carry over irrelevant context.
+- **Long threads cost more tokens.** Every message in the active thread is sent to the LLM. A sprawling thread inflates cost and latency with no benefit once the earlier topic is closed.
+- **Cross-conversation context is already handled.** You do not lose history by clearing. `memory_recall` (the assistant's persistent memory store) and conversation search give it access to past conversations when genuinely relevant. The old thread stays intact and searchable — `/clear` only starts a new one for the next topic.
+
+### When to use it
+
+Use `/clear` when:
+
+- You are switching to a clearly different topic (e.g. you were planning a trip, now you want to manage emails).
+- The conversation has grown long and responses feel less sharp or are mixing up context from earlier messages.
+- You notice the assistant referencing something from earlier in the thread that is no longer relevant.
+
+A good rule of thumb: one thread, one topic. When the topic changes, `/clear`.
+
+### What happens under the hood
+
+`/clear` creates a brand-new conversation with a fresh ID and routes all subsequent messages to it. The previous conversation is **not deleted** — it remains fully available in your conversation history and can be searched or referenced by the assistant's memory tools.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the Open Assistant documentation. This documentation covers architect
 - [Configuration Guide](setup/configuration.md) - Configure services and credentials
 - [Development Setup](setup/development.md) - Set up development environment
 - [Development Checklist](development-checklist.md) - Pre-flight checks before deploying
+- [Commands](commands.md) - Slash commands (`/clear` and more)
 
 ### Architecture
 - Architecture Overview
@@ -40,6 +41,7 @@ Welcome to the Open Assistant documentation. This documentation covers architect
 ```
 docs/
 ├── README.md                              # This file
+├── commands.md                            # Slash commands (/clear, etc.)
 ├── development-checklist.md                # Pre-flight checks before deploying
 ├── architecture/
 │   ├── system-architecture.md             # Deployment and infrastructure


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the `/clear` slash command, a feature that allows users to start fresh conversation threads. The documentation explains the command's purpose, usage, and underlying implementation.

## Key Changes
- **New documentation file** (`docs/commands.md`): Detailed guide covering:
  - Command syntax and response format
  - Rationale for using `/clear` (context clarity, token efficiency, memory integration)
  - When to use the command (topic switching, long threads, context drift)
  - Technical explanation of how the command works (new conversation ID, history preservation)
  
- **Updated navigation**: Added `/clear` command documentation link to:
  - `docs/index.md` - Main documentation index
  - `README.md` - Project README with brief feature description and link to full docs

## Notable Details
The documentation emphasizes that `/clear` is a UX feature for conversation management, not a data deletion tool. It clarifies that previous conversations remain searchable and accessible through the assistant's memory tools (`memory_recall` and conversation search), addressing potential user concerns about losing context.