### PR TITLE
Add "Reply in Thread" toggle for Slack integration

### DIFF
--- a/src/api/slack.py
+++ b/src/api/slack.py
@@ -18,6 +18,7 @@ from src.core.repositories.settings import SettingsRepository
 from src.core.tools.definitions import initialize_all_tools
 from src.models.slack import *
 from src.services.message_handler import MessageHandler
+from src.utils.settings import settings_truthy
 from src.services.settings import SettingsService
 from src.services.slack import SlackService
 from src.services.whatsapp_media import MediaHandler
@@ -254,10 +255,12 @@ async def handle_slack_event(
                     "I processed your message but couldn't generate a response. Please try again."
                 )
 
-            # Send reply
+            # Send reply (in-thread if configured)
+            reply_thread_ts = thread_ts if settings_truthy(settings_service.get_setting("slack.thread_replies")) else None
             slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
+                thread_ts=reply_thread_ts,
             )
 
             logger.info(
@@ -270,9 +273,11 @@ async def handle_slack_event(
         except Exception as e:
             logger.error(f"Failed to process Slack message: {e}", exc_info=True)
             try:
+                reply_thread_ts = thread_ts if settings_truthy(settings_service.get_setting("slack.thread_replies")) else None
                 slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",
+                    thread_ts=reply_thread_ts,
                 )
             except Exception as send_error:
                 logger.error(f"Failed to send error message: {send_error}")

--- a/src/api/slack.py
+++ b/src/api/slack.py
@@ -256,7 +256,11 @@ async def handle_slack_event(
                 )
 
             # Send reply (in-thread if configured)
-            reply_thread_ts = thread_ts if settings_truthy(settings_service.get_setting("slack.thread_replies")) else None
+            reply_thread_ts = (
+                thread_ts
+                if settings_truthy(settings_service.get_setting("slack.thread_replies"))
+                else None
+            )
             slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
@@ -273,7 +277,11 @@ async def handle_slack_event(
         except Exception as e:
             logger.error(f"Failed to process Slack message: {e}", exc_info=True)
             try:
-                reply_thread_ts = thread_ts if settings_truthy(settings_service.get_setting("slack.thread_replies")) else None
+                reply_thread_ts = (
+                    thread_ts
+                    if settings_truthy(settings_service.get_setting("slack.thread_replies"))
+                    else None
+                )
                 slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",

--- a/src/integrations/slack/socket_mode.py
+++ b/src/integrations/slack/socket_mode.py
@@ -11,6 +11,7 @@ from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
 from src.utils.logger import get_logger
+from src.utils.settings import settings_truthy
 
 if TYPE_CHECKING:
     from src.services.message_handler import MessageHandler
@@ -205,6 +206,7 @@ class SlackSocketModeHandler:
         user_id = event.get("user", "")
         channel_id = event.get("channel", "")
         text = event.get("text", "")
+        thread_ts = event.get("thread_ts") or event.get("ts", "")
         files = _extract_slack_files(event)
 
         logger.info(
@@ -243,7 +245,7 @@ class SlackSocketModeHandler:
         logger.debug(f"[Slack Socket Mode] Submitting coroutine to event loop: {self.event_loop}")
 
         asyncio.run_coroutine_threadsafe(
-            self._process_and_reply(channel_id, user_id, text, files),
+            self._process_and_reply(channel_id, user_id, text, files, thread_ts),
             self.event_loop,
         )
 
@@ -253,6 +255,7 @@ class SlackSocketModeHandler:
         user_id: str,
         text: str,
         files: Optional[List[Dict[str, Any]]] = None,
+        thread_ts: Optional[str] = None,
     ) -> None:
         """Process the message and send a reply."""
         logger.info(f"[Slack Socket Mode] Processing message from {user_id} in {channel_id}")
@@ -340,10 +343,12 @@ class SlackSocketModeHandler:
                 f"{response_text[:20]}..."
             )
 
-            # Send reply directly to channel
+            # Send reply (in-thread if configured)
+            reply_thread_ts = thread_ts if settings_truthy(self.settings_service.get_setting("slack.thread_replies")) else None
             self.slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
+                thread_ts=reply_thread_ts,
             )
 
             logger.info(
@@ -356,9 +361,11 @@ class SlackSocketModeHandler:
         except Exception as e:
             logger.error(f"[Slack Socket Mode] Failed to process message: {e}", exc_info=True)
             try:
+                reply_thread_ts = thread_ts if settings_truthy(self.settings_service.get_setting("slack.thread_replies")) else None
                 self.slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",
+                    thread_ts=reply_thread_ts,
                 )
             except Exception as send_error:
                 logger.error(f"[Slack Socket Mode] Failed to send error message: {send_error}")

--- a/src/integrations/slack/socket_mode.py
+++ b/src/integrations/slack/socket_mode.py
@@ -344,7 +344,11 @@ class SlackSocketModeHandler:
             )
 
             # Send reply (in-thread if configured)
-            reply_thread_ts = thread_ts if settings_truthy(self.settings_service.get_setting("slack.thread_replies")) else None
+            reply_thread_ts = (
+                thread_ts
+                if settings_truthy(self.settings_service.get_setting("slack.thread_replies"))
+                else None
+            )
             self.slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
@@ -361,7 +365,11 @@ class SlackSocketModeHandler:
         except Exception as e:
             logger.error(f"[Slack Socket Mode] Failed to process message: {e}", exc_info=True)
             try:
-                reply_thread_ts = thread_ts if settings_truthy(self.settings_service.get_setting("slack.thread_replies")) else None
+                reply_thread_ts = (
+                    thread_ts
+                    if settings_truthy(self.settings_service.get_setting("slack.thread_replies"))
+                    else None
+                )
                 self.slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -791,6 +791,17 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
         ui_widget="text",
         placeholder="U01ABCDEF,U02GHIJKL",
     ),
+    "slack.thread_replies": SettingDefinition(
+        key="slack.thread_replies",
+        display_name="Reply in Thread",
+        description="When enabled, Open Assistant replies in a thread under each incoming message instead of posting to the channel root. Useful when multiple users share a channel.",
+        value_type=SettingValueType.BOOL,
+        category=ConfigCategory.SLACK,
+        default_value=False,
+        env_var_name="SLACK_THREAD_REPLIES",
+        display_order=7,
+        ui_widget="toggle",
+    ),
     # ========================================================================
     # BRAVE SEARCH INTEGRATION
     # ========================================================================


### PR DESCRIPTION
## What

Adds a `slack.thread_replies` toggle (off by default) to the Slack settings page. When enabled, Open Assistant posts each reply as a threaded message under the triggering Slack message instead of at the channel root.

## Why

Enables a natural multi-user workflow: multiple people in a shared channel can each interact with Open Assistant, with every exchange visually contained in its own thread. The shared conversation context is intentional — it lets team members see and learn from each other's interactions.

## Changes

**`src/models/config.py`** — New `SettingDefinition` for `slack.thread_replies` (bool, default `false`, `display_order=7`, `ui_widget="toggle"`). Stored in the existing `settings` table; no migration required. The UI renders it automatically from the metadata.

**`src/api/slack.py`** — HTTP webhook path: reads `slack.thread_replies` via `settings_truthy(settings_service.get_setting(...))` and passes the incoming message's `thread_ts` to `send_message` when the setting is on. Applied to both the success reply and the error fallback reply. `thread_ts` was already being extracted from the event (line 166) but discarded.

**`src/integrations/slack/socket_mode.py`** — Socket Mode path: same pattern. Extracts `thread_ts = event.get("thread_ts") or event.get("ts", "")` (previously missing), threads it through `_process_and_reply`'s signature, and conditionally passes it to `send_message`.

`SlackService.send_message` and `SlackClient.send_message` already accepted an optional `thread_ts` and wired it to `chat_postMessage` — no changes needed there.

## Behaviour

| Setting | Result |
|---|---|
| Off (default) | Replies posted at channel root — identical to current behaviour |
| On | Reply posted in a thread under the message that triggered it; if the incoming message is already inside a thread, the reply goes into that same thread |