### PR TITLE
Add update.sh and installation & updates documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Welcome to the Open Assistant documentation. This documentation covers architect
 ## Quick Links
 
 ### Getting Started
+- [Installation & Updates](setup/install-and-update.md) - Install, update, volumes, and migration
 - [Configuration Guide](setup/configuration.md) - Configure services and credentials
 - [Development Setup](setup/development.md) - Set up development environment
 - [Development Checklist](development-checklist.md) - Pre-flight checks before deploying

--- a/docs/setup/install-and-update.md
+++ b/docs/setup/install-and-update.md
@@ -1,0 +1,162 @@
+# Installation & Updates
+
+This page explains what the one-liner installer does, how to update a running instance safely, and what lives inside each volume so you know exactly what data you own.
+
+---
+
+## install.sh — what it does
+
+The one-liner installer is designed to get you from zero to a running assistant in a single command, with no prior Docker experience required.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/open-assistant-org/open-assistant/main/install.sh | bash
+```
+
+It runs the following steps in order:
+
+### 1. Prerequisite check
+Verifies Docker is present and reachable. On Linux, if Docker is missing and the script is running as root, it auto-installs it via the distribution's package manager or the official `get.docker.com` script. On macOS, it exits early with a link to Docker Desktop.
+
+### 2. Configuration prompts
+Asks two things:
+
+- **Application URL** — where the assistant will be reachable (defaults to your local IP and port). Used for OAuth redirects and CORS.
+- **LLM provider** — OpenRouter, Groq, or a custom OpenAI-compatible endpoint. After choosing a provider, you pick a model and enter your API key (input is hidden).
+
+No configuration files to edit by hand.
+
+### 3. Generate encryption key
+A fresh Fernet key is generated using `python3`, `openssl`, or a throwaway Docker container as a fallback. This key is written to `.env` once and must never change — see [the encryption note below](#encryption-key).
+
+### 4. Write `.env`
+A minimal `.env` file is created in the current directory with exactly three variables:
+
+```
+DATABASE_URL=sqlite:///data/assistant.db
+ENCRYPTION_KEY=<generated>
+APP_URL=<your URL>
+CORS_ORIGINS=<your URL>
+```
+
+All other settings (LLM provider, API keys, integrations) are stored in the database and managed through the Settings UI at `/settings`.
+
+### 5. Start the container
+Three host directories are created — `data/`, `logs/`, `tmp/` — and bind-mounted into the container. See [Volume contents](#volume-contents) below for what goes where. The container is started with `--restart unless-stopped`, so it comes back automatically after a reboot.
+
+### 6. Wait for health
+Polls `GET /health` every two seconds for up to two minutes.
+
+### 7. Push LLM settings
+POSTs your LLM provider/model/key to the settings API so the assistant is ready to use immediately without opening the UI.
+
+### 8. Test the connection
+Sends a test request to confirm the LLM is reachable and the key is valid.
+
+---
+
+## update.sh — safe, zero-data-loss updates
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/open-assistant-org/open-assistant/main/update.sh | bash
+```
+
+Or if you have a local copy:
+
+```bash
+bash update.sh
+```
+
+The updater never touches your data. It only replaces the container image.
+
+### How it works
+
+1. **Detect the installation** — reads the running `open-assistant` container's bind-mount paths and port binding via `docker inspect`. The install directory and `.env` file are derived automatically; you do not need to supply them.
+
+2. **Pull the new image** — downloads `ghcr.io/open-assistant-org/open-assistant:latest` before stopping anything. If the pull fails (no network, registry issue), the script exits and the running container is left untouched.
+
+3. **Check if an update is available** — compares the running container's image digest against the freshly pulled one. If they match, the script exits cleanly with "already up to date". Set `FORCE_UPDATE=1` to restart anyway.
+
+4. **Replace the container** — stops the old container, removes it, and starts a new one with the identical bind mounts, port, and `.env` file. The window between stop and start is typically under five seconds.
+
+5. **Wait for health** — same polling loop as the installer.
+
+6. **Prune dangling layers** — removes the old image layers to free disk space.
+
+### Rollback
+
+Docker does not automatically keep the previous image tag. If you need to roll back to a specific release, pin the image tag:
+
+```bash
+docker stop open-assistant
+docker rm open-assistant
+docker run -d \
+  --name open-assistant \
+  --restart unless-stopped \
+  -p 8080:8080 \
+  -v "$PWD/data:/app/data" \
+  -v "$PWD/logs:/app/logs" \
+  -v "$PWD/tmp:/app/tmp" \
+  --env-file .env \
+  -e LOG_LEVEL=INFO \
+  -e ENVIRONMENT=production \
+  -e WHATSAPP_BRIDGE_PORT=3001 \
+  -e WHATSAPP_SESSION_DIR=/app/data/whatsapp_session \
+  -e TMP_DIR=/app/tmp \
+  ghcr.io/open-assistant-org/open-assistant:<tag>
+```
+
+Replace `<tag>` with the release tag you want (e.g. `v1.2.0`). Your data is unaffected.
+
+---
+
+## Volume contents
+
+The installer creates three directories next to your `.env` file and bind-mounts them into the container. Because they are bind mounts on your host, the data is entirely yours — no `docker volume` commands needed to access or back it up.
+
+```
+<install dir>/
+├── .env          ← bootstrap config (DB URL, encryption key, app URL)
+├── data/         ← persistent data (mounted at /app/data)
+├── logs/         ← application logs (mounted at /app/logs)
+└── tmp/          ← ephemeral scratch space (mounted at /app/tmp)
+```
+
+### `data/`
+
+Everything that must survive a container restart or update lives here.
+
+| Path | Contents |
+|------|----------|
+| `data/assistant.db` | SQLite database — all settings, conversation history, scheduled jobs, audit log |
+| `data/whatsapp_session/` | WhatsApp Web session files (keeps you logged in across restarts) |
+
+The database holds the complete state of the assistant: LLM configuration, integration credentials, memory, cron jobs, and OAuth tokens. All sensitive values (API keys, OAuth tokens, passwords) are stored encrypted — see [Encryption key](#encryption-key).
+
+### `logs/`
+
+Structured application logs written by the assistant process. Safe to rotate or clear at any time — the running assistant is unaffected.
+
+### `tmp/`
+
+Ephemeral working files: downloaded attachments, intermediate tool outputs, and large tool results that are offloaded from the LLM context window. This directory can be cleared at any time and will be recreated on the next relevant operation.
+
+---
+
+## Migrating to a new host
+
+Because everything persistent is in `data/`, migration is straightforward:
+
+1. **Copy** your `data/` directory and `.env` file to the new host.
+2. **Run the installer** on the new host, but choose **not** to overwrite the existing `.env` when prompted.
+3. The assistant starts with all your settings, history, and credentials intact.
+
+Alternatively, after a fresh install on the new host, stop the container, replace the new `data/` with your copy, and restart.
+
+---
+
+## Encryption key
+
+!!! warning "Never change the encryption key after first run"
+    All credentials stored in the database — OAuth tokens, API keys, passwords — are encrypted with the Fernet key in `ENCRYPTION_KEY`. If you change this value (or lose it), the assistant cannot decrypt any stored credentials and all integrations will stop working. You would need to re-authenticate every service from scratch.
+
+    The key is generated once by `install.sh` and written to `.env`. Back up your `.env` file alongside your `data/` directory. Together, these two artefacts are everything you need to restore or migrate a running instance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Setup:
+      - Installation & Updates: setup/install-and-update.md
       - Configuration: setup/configuration.md
       - Development: setup/development.md
   - Development Checklist: development-checklist.md

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Open Assistant — Updater
+# https://open-assistant.org
+#
+# Usage:
+#   bash update.sh
+#   curl -fsSL https://raw.githubusercontent.com/open-assistant-org/open-assistant/main/update.sh | bash
+#
+# Updates a running Open Assistant instance that was installed with install.sh.
+# Your data, settings, and credentials are never touched — only the container
+# image is replaced.
+# =============================================================================
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+DOCKER_IMAGE="ghcr.io/open-assistant-org/open-assistant:latest"
+CONTAINER_NAME="open-assistant"
+
+# -----------------------------------------------------------------------------
+# Colors & formatting
+# -----------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+print_banner() {
+  echo ""
+  echo -e "${CYAN}${BOLD}"
+  echo "  ╔═══════════════════════════════════════════╗"
+  echo "  ║          Open Assistant Update            ║"
+  echo "  ║       Self-hosted AI assistant bot        ║"
+  echo "  ╚═══════════════════════════════════════════╝"
+  echo -e "${RESET}"
+}
+
+info()    { echo -e "  ${BLUE}ℹ${RESET}  $*"; }
+success() { echo -e "  ${GREEN}✔${RESET}  $*"; }
+warn()    { echo -e "  ${YELLOW}⚠${RESET}  $*"; }
+error()   { echo -e "  ${RED}✖${RESET}  $*" >&2; }
+step()    { echo -e "\n${BOLD}${CYAN}▶ $*${RESET}"; }
+
+# -----------------------------------------------------------------------------
+# Detect the running installation from the existing container
+# -----------------------------------------------------------------------------
+detect_installation() {
+  step "Detecting installation"
+
+  if ! command -v docker &>/dev/null; then
+    error "Docker is not installed or not in PATH."
+    exit 1
+  fi
+
+  if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    error "No running container named '${CONTAINER_NAME}' found."
+    error "Make sure Open Assistant is running, or install it first:"
+    error "  curl -fsSL https://raw.githubusercontent.com/open-assistant-org/open-assistant/main/install.sh | bash"
+    exit 1
+  fi
+
+  # Read host port from the container's port bindings
+  APP_PORT=$(docker inspect "$CONTAINER_NAME" \
+    --format '{{range $p, $conf := .HostConfig.PortBindings}}{{if eq $p "8080/tcp"}}{{(index $conf 0).HostPort}}{{end}}{{end}}' \
+    2>/dev/null || true)
+  APP_PORT="${APP_PORT:-8080}"
+
+  # Derive install dir from the bind-mount source for /app/data
+  local data_src
+  data_src=$(docker inspect "$CONTAINER_NAME" \
+    --format '{{range .Mounts}}{{if eq .Destination "/app/data"}}{{.Source}}{{end}}{{end}}' \
+    2>/dev/null || true)
+
+  if [[ -z "$data_src" ]]; then
+    error "Could not read bind-mount info from container '${CONTAINER_NAME}'."
+    error "Was it installed with install.sh? Named Docker volumes are not supported by this updater."
+    exit 1
+  fi
+
+  INSTALL_DIR="${data_src%/data}"
+  ENV_FILE="${INSTALL_DIR}/.env"
+
+  if [[ ! -f "$ENV_FILE" ]]; then
+    error ".env not found at ${ENV_FILE}"
+    error "Expected it next to the data/ directory created by install.sh."
+    exit 1
+  fi
+
+  success "Installation directory: ${INSTALL_DIR}"
+  success "Port: ${APP_PORT}"
+}
+
+# -----------------------------------------------------------------------------
+# Check whether an update is available
+# -----------------------------------------------------------------------------
+check_for_update() {
+  step "Checking for updates"
+
+  local running_id new_id
+  running_id=$(docker inspect "$CONTAINER_NAME" --format '{{.Image}}' 2>/dev/null || true)
+
+  info "Pulling latest image manifest..."
+  if ! docker pull --quiet "$DOCKER_IMAGE" 2>/dev/null; then
+    error "Failed to pull image. Check your internet connection or registry access."
+    exit 1
+  fi
+
+  new_id=$(docker inspect "$DOCKER_IMAGE" --format '{{.Id}}' 2>/dev/null || true)
+
+  if [[ "$running_id" == "$new_id" ]]; then
+    success "Already running the latest version — nothing to do."
+    echo ""
+    echo -e "  ${DIM}To force a restart anyway, run:${RESET}"
+    echo -e "  ${DIM}  FORCE_UPDATE=1 bash update.sh${RESET}"
+    echo ""
+    if [[ "${FORCE_UPDATE:-0}" != "1" ]]; then
+      exit 0
+    fi
+    warn "FORCE_UPDATE=1 — restarting anyway."
+  else
+    success "New version available — proceeding with update."
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Replace the container (stop old → start new, data untouched)
+# -----------------------------------------------------------------------------
+replace_container() {
+  step "Applying update"
+
+  local data_dir="${INSTALL_DIR}/data"
+  local logs_dir="${INSTALL_DIR}/logs"
+  local tmp_dir="${INSTALL_DIR}/tmp"
+
+  # Re-create dirs in case any went missing (safe no-op if they exist)
+  mkdir -p "$data_dir" "$logs_dir" "$tmp_dir"
+
+  info "Stopping container..."
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker rm   "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  success "Old container removed"
+
+  info "Starting updated container..."
+  docker run -d \
+    --name "$CONTAINER_NAME" \
+    --restart unless-stopped \
+    -p "${APP_PORT}:8080" \
+    -v "${data_dir}:/app/data" \
+    -v "${logs_dir}:/app/logs" \
+    -v "${tmp_dir}:/app/tmp" \
+    --env-file "$ENV_FILE" \
+    -e "LOG_LEVEL=${LOG_LEVEL:-INFO}" \
+    -e "ENVIRONMENT=${ENVIRONMENT:-production}" \
+    -e "WHATSAPP_BRIDGE_PORT=3001" \
+    -e "WHATSAPP_SESSION_DIR=/app/data/whatsapp_session" \
+    -e "TMP_DIR=/app/tmp" \
+    -e "CRON_MAX_CONCURRENT_JOBS=${CRON_MAX_CONCURRENT_JOBS:-5}" \
+    -e "CRON_JOB_TIMEOUT_SECONDS=${CRON_JOB_TIMEOUT_SECONDS:-600}" \
+    -e "INSTANCE_ID=${HOSTNAME:-instance-1}" \
+    --health-cmd "curl -f http://localhost:8080/health" \
+    --health-interval 30s \
+    --health-timeout 10s \
+    --health-retries 3 \
+    --health-start-period 40s \
+    "$DOCKER_IMAGE" >/dev/null
+
+  success "Container started"
+}
+
+# -----------------------------------------------------------------------------
+# Wait for the new container to pass its health check
+# -----------------------------------------------------------------------------
+wait_for_health() {
+  step "Waiting for application to be ready"
+
+  local max=60 attempt=0 ok=false
+  echo -ne "  ${CYAN}⠋${RESET}  Starting up"
+  while (( attempt < max )); do
+    if curl -sf "http://localhost:${APP_PORT}/health" -o /tmp/oa_health.json 2>/dev/null; then
+      ok=true; break
+    fi
+    echo -ne "."; sleep 2; attempt=$((attempt + 1))
+  done
+  echo ""
+
+  if [[ "$ok" == "false" ]]; then
+    error "App did not become healthy after $((max * 2))s."
+    error "Check logs: docker logs ${CONTAINER_NAME}"
+    exit 1
+  fi
+
+  local status="ok"
+  command -v jq &>/dev/null && [[ -f /tmp/oa_health.json ]] \
+    && status=$(jq -r '.status // "ok"' /tmp/oa_health.json 2>/dev/null || echo "ok")
+  success "Application is healthy (${status})"
+}
+
+# -----------------------------------------------------------------------------
+# Prune the old (now-dangling) image to free disk space
+# -----------------------------------------------------------------------------
+prune_old_image() {
+  step "Cleaning up"
+  if docker image prune -f --filter "dangling=true" >/dev/null 2>&1; then
+    success "Old image layers removed"
+  else
+    info "Nothing to prune"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Final summary
+# -----------------------------------------------------------------------------
+print_summary() {
+  local app_url
+  app_url=$(grep '^APP_URL=' "$ENV_FILE" 2>/dev/null | cut -d'=' -f2- | tr -d '"' || true)
+  app_url="${app_url:-http://localhost:${APP_PORT}}"
+
+  echo ""
+  echo -e "${GREEN}${BOLD}══════════════════════════════════════════════════${RESET}"
+  echo -e "${GREEN}${BOLD}  Open Assistant updated successfully!${RESET}"
+  echo -e "${GREEN}${BOLD}══════════════════════════════════════════════════${RESET}"
+  echo ""
+  echo -e "  ${BOLD}Chat UI:${RESET}     ${CYAN}${app_url}${RESET}"
+  echo -e "  ${BOLD}Settings:${RESET}    ${CYAN}${app_url}/settings${RESET}"
+  echo -e "  ${BOLD}Logs:${RESET}        ${DIM}docker logs -f ${CONTAINER_NAME}${RESET}"
+  echo ""
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+  print_banner
+  detect_installation
+  check_for_update
+  replace_container
+  wait_for_health
+  prune_old_image
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **`update.sh`** — a safe, zero-data-loss updater for instances installed with `install.sh`
- **`docs/setup/install-and-update.md`** — new documentation page covering the installer, the updater, volume contents, migration, and the encryption key invariant
- **`mkdocs.yml` / `docs/index.md`** — registers the new page under Setup

## `update.sh` design

The updater is built around one safety principle: **pull before stopping**. The sequence is:

1. Auto-detect the running installation via `docker inspect` (no manual path needed)
2. Pull the new image — if this fails, the running container is left untouched
3. Compare image digests — exit cleanly if already current (`FORCE_UPDATE=1` overrides)
4. Stop → remove old container → start new one with identical bind mounts, port, and `.env`
5. Poll `/health` until ready
6. Prune dangling image layers

Data volumes (`data/`, `logs/`, `tmp/`) and the `.env` file are never modified.

## Documentation page

Covers:

- What `install.sh` does, step by step
- What `update.sh` does and why it is safe
- What each volume mount contains (with a table for `data/`)
- How to migrate to a new host
- The encryption key invariant: all credentials are encrypted with `ENCRYPTION_KEY`; changing it after first run breaks every stored integration