### PR TITLE
Add "Reply Only on Mention" toggle for Slack integration

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -223,6 +223,35 @@ Restrict which Slack users can interact with the bot. To find a user ID:
 
 Leave this field empty to allow all workspace members.
 
+### Reply in Thread
+
+When enabled, Open Assistant posts its response as a **threaded reply** under the triggering message rather than at the channel root. Off by default.
+
+Useful when multiple users share a channel — each user's exchange stays visually contained in its own thread while the shared conversation context continues to work as before.
+
+### Reply Only on Mention
+
+When enabled, Open Assistant **only responds when directly @mentioned** (e.g. `@OpenAssistant`). All other channel messages are silently ignored, letting humans converse freely without constant bot interruptions. Off by default.
+
+When the bot is mentioned, the `@mention` token is stripped from the message before processing, so it does not appear as part of the prompt.
+
+**Recommended combo:** Enable both **Reply in Thread** and **Reply Only on Mention** together for the ideal shared-channel workflow:
+
+```
+#general
+Human A:  "hey team, let's ship on Friday"
+Human B:  "works for me 👍"
+Human A:  "@OpenAssistant can you draft a release checklist?"
+          └─ [thread] OpenAssistant: "Sure! Here's a checklist: …"
+Human B:  "looks good to me"
+Human A:  "@OpenAssistant add a rollback step"
+          └─ [thread] OpenAssistant: "Added: …"
+```
+
+Humans talk freely in the channel; the bot only enters when called by name and always replies in-thread.
+
+> **Note:** The conversation history shown to the AI contains only @mention messages and bot replies — human-to-human chatter is never included in the context.
+
 ## How Messages Work
 
 ### Socket Mode (Default)
@@ -288,8 +317,7 @@ Leave this field empty to allow all workspace members.
 
 ## Limitations
 
-- The bot responds in the channel, not as top-level channel messages
-- Socket Mode and HTTP webhooks cannot be used simultaneously for receiving events - choose one based on your network setup
+- Socket Mode and HTTP webhooks cannot be used simultaneously for receiving events — choose one based on your network setup
 
 ## File Handling
 
@@ -306,4 +334,4 @@ Media processing (image analysis, OCR, transcription) is not handled by the Slac
 
 ---
 
-**Last Updated**: February 2026
+**Last Updated**: August 2026

--- a/src/api/slack.py
+++ b/src/api/slack.py
@@ -182,6 +182,15 @@ async def handle_slack_event(
         logger.info(f"Ignoring message from non-allowed Slack user {user_id}")
         return {"ok": True, "message": "Ignored (not allowed)"}
 
+    # Filter to mentions only if configured
+    if settings_truthy(settings_service.get_setting("slack.mention_only")):
+        bot_user_id = slack_service.get_bot_user_id()
+        mention_token = f"<@{bot_user_id}>" if bot_user_id else None
+        if not mention_token or mention_token not in text:
+            logger.debug(f"mention_only: ignoring non-mention from {user_id}")
+            return {"ok": True}
+        text = text.replace(mention_token, "").strip()
+
     async def process_and_reply():
         try:
             # Verify LLM configuration

--- a/src/integrations/slack/socket_mode.py
+++ b/src/integrations/slack/socket_mode.py
@@ -98,6 +98,7 @@ class SlackSocketModeHandler:
         # Thread for running the client
         self._thread: Optional[threading.Thread] = None
         self._running = False
+        self._bot_user_id: Optional[str] = None
 
         logger.info(
             f"[Slack Socket Mode] Handler initialized (app_token={'configured' if app_token else 'MISSING'}, "
@@ -115,6 +116,17 @@ class SlackSocketModeHandler:
         self._thread = threading.Thread(target=self._run_client, daemon=True)
         self._thread.start()
         logger.info("Slack Socket Mode connection started")
+
+    def _get_bot_user_id(self) -> Optional[str]:
+        """Lazily fetch and cache the bot's Slack user ID via auth.test."""
+        if not self._bot_user_id:
+            try:
+                response = self.client.web_client.auth_test()
+                self._bot_user_id = response.get("user_id") or ""
+                logger.info(f"[Slack Socket Mode] Bot user ID: {self._bot_user_id}")
+            except Exception as e:
+                logger.warning(f"[Slack Socket Mode] Could not fetch bot user ID: {e}")
+        return self._bot_user_id or None
 
     def _run_client(self) -> None:
         """Run the Socket Mode client (blocking)."""
@@ -229,6 +241,17 @@ class SlackSocketModeHandler:
             return
 
         logger.info(f"[Slack Socket Mode] User {user_id} is allowed - processing message")
+
+        # Filter to mentions only if configured
+        if settings_truthy(self.settings_service.get_setting("slack.mention_only")):
+            bot_user_id = self._get_bot_user_id()
+            mention_token = f"<@{bot_user_id}>" if bot_user_id else None
+            if not mention_token or mention_token not in text:
+                logger.debug(
+                    f"[Slack Socket Mode] mention_only: ignoring non-mention from {user_id}"
+                )
+                return
+            text = text.replace(mention_token, "").strip()
 
         # Process message in background using the main event loop
         if self.event_loop is None:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -802,6 +802,17 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
         display_order=7,
         ui_widget="toggle",
     ),
+    "slack.mention_only": SettingDefinition(
+        key="slack.mention_only",
+        display_name="Reply Only on Mention",
+        description="When enabled, Open Assistant only responds when directly @mentioned. All other channel messages are ignored, letting humans converse freely. Best combined with 'Reply in Thread' so each @mention starts a clean threaded reply.",
+        value_type=SettingValueType.BOOL,
+        category=ConfigCategory.SLACK,
+        default_value=False,
+        env_var_name="SLACK_MENTION_ONLY",
+        display_order=8,
+        ui_widget="toggle",
+    ),
     # ========================================================================
     # BRAVE SEARCH INTEGRATION
     # ========================================================================

--- a/src/services/slack.py
+++ b/src/services/slack.py
@@ -133,6 +133,16 @@ class SlackService(BaseService):
                 "message": f"Connection failed: {str(e)}",
             }
 
+    def get_bot_user_id(self) -> Optional[str]:
+        """Get the bot's Slack user ID (from auth.test)."""
+        try:
+            client = self._get_client()
+            info = client.get_bot_info()
+            return info.get("user_id") or None
+        except Exception as e:
+            logger.error(f"Failed to get bot user ID: {e}")
+            return None
+
     def is_user_allowed(self, user_id: str) -> bool:
         """Check if a Slack user is allowed to interact with the bot."""
         allowed_ids_str = self.settings_repo.get("slack.allowed_user_ids") or ""


### PR DESCRIPTION
## Summary

Follow-up to #70 ("Reply in Thread"). Adds a second Slack toggle — **Reply Only on Mention** (`slack.mention_only`) — so the bot silently ignores all channel messages unless someone directly `@mentions` it.

This lets teammates converse freely in a shared channel without constant bot interruptions; the bot only wakes up when called by name.

## Changes

- **`src/models/config.py`** — new `slack.mention_only` setting (`BOOL`, off by default, `display_order=8`, renders as a toggle in the Integrations UI alongside the existing "Reply in Thread" toggle)
- **`src/services/slack.py`** — new `get_bot_user_id()` helper that calls `auth.test` and returns the bot's Slack user ID (used by the webhook path to resolve the `<@BOT_USER_ID>` mention token)
- **`src/integrations/slack/socket_mode.py`** — lazy-cached `_get_bot_user_id()` (calls `auth.test` once via the existing `web_client`, caches in `self._bot_user_id`); mention filter added in `_handle_request` after the user-allowed check
- **`src/api/slack.py`** — same mention filter added in `handle_slack_event` after the user-allowed check

## How it works

When `mention_only` is enabled:
1. Every incoming `message` event is checked for `<@BOT_USER_ID>` in the text.
2. If the token is absent the message is silently dropped — no processing, no reply.
3. If the token is present it is stripped from the text before being passed to the `MessageHandler`, so the bot never sees the raw mention as part of the prompt.
4. The bot replies normally (respecting `thread_replies` if also enabled).

**Conversation history** is naturally clean: since the bot never processes human-to-human messages, the stored conversation context contains only `@mention → bot reply` pairs. No special reconstruction is needed.

## Recommended combo

Enable both `slack.mention_only` **and** `slack.thread_replies` for the ideal team workflow:

```
#general
Human A:  "hey team, let's ship on Friday"
Human B:  "works for me"
Human A:  "@OpenAssistant can you draft a release checklist?"
          └─ [thread] OpenAssistant: "Sure! Here's a checklist: …"
Human B:  "looks good"
Human A:  "@OpenAssistant add a rollback step"
          └─ [thread] OpenAssistant: "Added: …"
```

Humans talk freely; the bot only enters when explicitly called, and always replies in-thread.

## Backwards compatibility

Both settings default to `false`, so existing deployments are unaffected.