### PR TITLE
Limit parallel web search and browser calls to prevent rate-limit bursts and headless browser crashes

### DIFF
--- a/src/core/concurrency.py
+++ b/src/core/concurrency.py
@@ -105,3 +105,47 @@ def get_subtask_semaphore() -> asyncio.Semaphore:
 def current_subtask_depth() -> int:
     """Return the sub-task depth of the current execution context."""
     return subtask_depth.get()
+
+
+# ---------------------------------------------------------------------------
+# Web search concurrency limit
+# ---------------------------------------------------------------------------
+# Caps the number of parallel web_search calls so that fan-out sub-tasks
+# cannot simultaneously blast the Brave / DuckDuckGo APIs and trigger rate
+# limits or bans.  A limit of 1 means searches from concurrent sub-tasks are
+# queued and issued one-at-a-time; raise it only if you have a paid API tier
+# with a higher rate limit.  Override with MAX_CONCURRENT_SEARCHES.
+MAX_CONCURRENT_SEARCHES = max(1, int(os.getenv("MAX_CONCURRENT_SEARCHES", "1")))
+
+_search_semaphore: Optional[asyncio.Semaphore] = None
+
+
+def get_search_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide web-search concurrency semaphore."""
+    global _search_semaphore
+    if _search_semaphore is None:
+        _search_semaphore = asyncio.Semaphore(MAX_CONCURRENT_SEARCHES)
+        logger.info("Web search semaphore initialized with limit=%d", MAX_CONCURRENT_SEARCHES)
+    return _search_semaphore
+
+
+# ---------------------------------------------------------------------------
+# Browser concurrency limit
+# ---------------------------------------------------------------------------
+# Each browse_url call spawns a fresh Playwright/Chromium instance.  Running
+# several in parallel exhausts CPU, RAM, and file-descriptor limits, causing
+# the headless browser to hang or crash.  Serialising all browser tool calls
+# behind a semaphore of 1 means only one Playwright session is active at a
+# time across all concurrent sub-tasks.  Override with MAX_CONCURRENT_BROWSERS.
+MAX_CONCURRENT_BROWSERS = max(1, int(os.getenv("MAX_CONCURRENT_BROWSERS", "1")))
+
+_browser_semaphore: Optional[asyncio.Semaphore] = None
+
+
+def get_browser_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide browser concurrency semaphore."""
+    global _browser_semaphore
+    if _browser_semaphore is None:
+        _browser_semaphore = asyncio.Semaphore(MAX_CONCURRENT_BROWSERS)
+        logger.info("Browser semaphore initialized with limit=%d", MAX_CONCURRENT_BROWSERS)
+    return _browser_semaphore

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -5,6 +5,7 @@ import json
 import time
 from typing import Any, Dict, Optional, Tuple
 
+from src.core.concurrency import get_browser_semaphore, get_search_semaphore
 from src.core.tools.registry import get_tool_registry
 from src.models.nextcloud import UploadFileRequest as NextcloudUploadFileRequest
 from src.models.outlook import UploadFileRequest as OutlookUploadFileRequest
@@ -697,23 +698,33 @@ class ToolExecutor:
         elif tool_name == "yahoo_finance_search":
             return service.search(**arguments)
 
-        # Brave Search tools
+        # Brave Search tools — serialised globally to avoid API rate-limit
+        # bursts when multiple sub-tasks fan out parallel searches.
         elif tool_name == "web_search":
-            return service.web_search(**arguments)
+            async with get_search_semaphore():
+                return service.web_search(**arguments)
 
-        # Browser tools (async)
+        # Browser tools — serialised globally so that parallel sub-tasks
+        # cannot spawn multiple Playwright/Chromium instances simultaneously,
+        # which would exhaust CPU/RAM and cause the headless browser to crash.
         elif tool_name == "browse_url":
-            return await service.browse_url(**arguments)
+            async with get_browser_semaphore():
+                return await service.browse_url(**arguments)
         elif tool_name == "browse_get_tree":
-            return await service.browse_get_tree(**arguments)
+            async with get_browser_semaphore():
+                return await service.browse_get_tree(**arguments)
         elif tool_name == "browse_action":
-            return await service.browse_action(**arguments)
+            async with get_browser_semaphore():
+                return await service.browse_action(**arguments)
         elif tool_name == "browse_scroll":
-            return await service.browse_scroll(**arguments)
+            async with get_browser_semaphore():
+                return await service.browse_scroll(**arguments)
         elif tool_name == "browse_extract":
-            return await service.browse_extract()
+            async with get_browser_semaphore():
+                return await service.browse_extract()
         elif tool_name == "browse_fetch":
-            return await service.browse_fetch(**arguments)
+            async with get_browser_semaphore():
+                return await service.browse_fetch(**arguments)
 
         # System tools
         elif tool_name == "system_fetch_logs":


### PR DESCRIPTION
When the LLM fans out parallel sub-tasks, concurrent web_search calls were
hitting Brave/DuckDuckGo rate limits (DuckDuckGo had no throttle at all), and
concurrent browse_url calls each spawned a fresh Playwright/Chromium instance,
exhausting CPU and RAM.

Add two process-wide asyncio semaphores in concurrency.py:
- get_search_semaphore(): limits concurrent web searches (default 1, env MAX_CONCURRENT_SEARCHES)
- get_browser_semaphore(): limits concurrent browser operations (default 1, env MAX_CONCURRENT_BROWSERS)

Apply both at the executor call sites so all six browser tools and web_search
are serialised across sub-tasks, queuing rather than racing.