### PR TITLE
Scope Slack conversations to threads when "Reply in Thread" is enabled

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -227,7 +227,15 @@ Leave this field empty to allow all workspace members.
 
 When enabled, Open Assistant posts its response as a **threaded reply** under the triggering message rather than at the channel root. Off by default.
 
-Useful when multiple users share a channel — each user's exchange stays visually contained in its own thread while the shared conversation context continues to work as before.
+This applies to *every* message the bot sends for that exchange, including out-of-band progress updates such as background sub-task status — they land in the same thread, not at the channel root.
+
+Enabling it also **scopes conversation context to the thread**. Each Slack thread becomes its own conversation: it has its own history, and background sub-tasks dispatched in one thread report back only into that thread. Two people working in two threads of the same channel can no longer see or disturb each other's context.
+
+Useful when multiple users share a channel — each user's exchange stays contained in its own thread, both visually and in what the AI sees.
+
+> **Note:** With the toggle **off**, behaviour is unchanged: all messages in a channel share one channel-wide conversation. Use the `/clear` command to start a fresh context in that mode.
+>
+> With the toggle **on**, a brand-new top-level message starts a brand-new thread, and therefore a brand-new conversation with no prior history. The bot does not read messages posted in a thread before it was first mentioned there.
 
 ### Reply Only on Mention
 
@@ -260,14 +268,14 @@ Humans talk freely in the channel; the bot only enters when called by name and a
 2. A user sends a message in a channel where the bot is present (or via DM)
 3. Slack pushes the event through the WebSocket
 4. The bot processes the message through Open Assistant's message handler
-5. The response is sent back as a threaded reply in the same channel
+5. The response is sent back to the same channel — as a threaded reply when **Reply in Thread** is enabled, otherwise at the channel root
 
 ### HTTP Webhooks (Alternative)
 
 1. A user sends a message in a channel where the bot is present (or via DM)
 2. Slack sends the event to your webhook URL (`/api/slack/webhook/events`)
 3. The bot processes the message through Open Assistant's message handler
-4. The response is sent back as a threaded reply in the same channel
+4. The response is sent back to the same channel — as a threaded reply when **Reply in Thread** is enabled, otherwise at the channel root
 
 ## Troubleshooting
 

--- a/src/api/slack.py
+++ b/src/api/slack.py
@@ -191,6 +191,19 @@ async def handle_slack_event(
             return {"ok": True}
         text = text.replace(mention_token, "").strip()
 
+    # Resolve the thread scope once, up front, so the reply target, the
+    # progress-notification target and the conversation identity can never
+    # disagree — and so the error handler below can still reply in-thread.
+    #
+    # With "Reply in Thread" on, each Slack thread is its own conversation: the
+    # contact identifier carries the thread_ts, so context stays inside the
+    # thread instead of being shared channel-wide.  With it off the identifier
+    # stays the bare channel_id, preserving the existing channel-wide
+    # conversation behaviour.
+    thread_replies = settings_truthy(settings_service.get_setting("slack.thread_replies"))
+    reply_thread_ts = thread_ts if (thread_replies and thread_ts) else None
+    contact_identifier = f"{channel_id}:{reply_thread_ts}" if reply_thread_ts else channel_id
+
     async def process_and_reply():
         try:
             # Verify LLM configuration
@@ -241,16 +254,18 @@ async def handle_slack_event(
                 message=effective_message,
                 conversation_id=None,
                 channel="slack",
-                contact_identifier=channel_id,
+                contact_identifier=contact_identifier,
                 max_idle_seconds=SLACK_NEW_CHAT_IDLE_SECONDS,
                 metadata={
                     "source": "slack_event",
                     "channel": channel_id,
                     "user": user_id,
+                    "thread_ts": reply_thread_ts,
                     "has_media": bool(files),
                 },
                 image_base64=image_base64,
                 image_mimetype=image_mimetype,
+                reply_thread_ts=reply_thread_ts,
             )
 
             response_text = result["response"] or ""
@@ -265,11 +280,6 @@ async def handle_slack_event(
                 )
 
             # Send reply (in-thread if configured)
-            reply_thread_ts = (
-                thread_ts
-                if settings_truthy(settings_service.get_setting("slack.thread_replies"))
-                else None
-            )
             slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
@@ -286,11 +296,6 @@ async def handle_slack_event(
         except Exception as e:
             logger.error(f"Failed to process Slack message: {e}", exc_info=True)
             try:
-                reply_thread_ts = (
-                    thread_ts
-                    if settings_truthy(settings_service.get_setting("slack.thread_replies"))
-                    else None
-                )
                 slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",

--- a/src/integrations/slack/socket_mode.py
+++ b/src/integrations/slack/socket_mode.py
@@ -283,6 +283,19 @@ class SlackSocketModeHandler:
         """Process the message and send a reply."""
         logger.info(f"[Slack Socket Mode] Processing message from {user_id} in {channel_id}")
 
+        # Resolve the thread scope once, up front, so the reply target, the
+        # progress-notification target and the conversation identity can never
+        # disagree — and so the error handler below can still reply in-thread.
+        #
+        # With "Reply in Thread" on, each Slack thread is its own conversation:
+        # the contact identifier carries the thread_ts, so context stays inside
+        # the thread instead of being shared channel-wide.  With it off the
+        # identifier stays the bare channel_id, preserving the existing
+        # channel-wide conversation behaviour.
+        thread_replies = settings_truthy(self.settings_service.get_setting("slack.thread_replies"))
+        reply_thread_ts = thread_ts if (thread_replies and thread_ts) else None
+        contact_identifier = f"{channel_id}:{reply_thread_ts}" if reply_thread_ts else channel_id
+
         try:
             # Verify LLM configuration
             api_key = self.settings_service.get_config_with_fallback("llm.api_key")
@@ -338,16 +351,18 @@ class SlackSocketModeHandler:
                 message=effective_message,
                 conversation_id=None,
                 channel="slack",
-                contact_identifier=channel_id,
+                contact_identifier=contact_identifier,
                 max_idle_seconds=SLACK_NEW_CHAT_IDLE_SECONDS,
                 metadata={
                     "source": "slack_socket_mode",
                     "channel": channel_id,
                     "user": user_id,
+                    "thread_ts": reply_thread_ts,
                     "has_media": bool(files),
                 },
                 image_base64=image_base64,
                 image_mimetype=image_mimetype,
+                reply_thread_ts=reply_thread_ts,
             )
 
             response_text = result.get("response") or ""
@@ -367,11 +382,6 @@ class SlackSocketModeHandler:
             )
 
             # Send reply (in-thread if configured)
-            reply_thread_ts = (
-                thread_ts
-                if settings_truthy(self.settings_service.get_setting("slack.thread_replies"))
-                else None
-            )
             self.slack_service.send_message(
                 channel=channel_id,
                 message=response_text,
@@ -388,11 +398,6 @@ class SlackSocketModeHandler:
         except Exception as e:
             logger.error(f"[Slack Socket Mode] Failed to process message: {e}", exc_info=True)
             try:
-                reply_thread_ts = (
-                    thread_ts
-                    if settings_truthy(self.settings_service.get_setting("slack.thread_replies"))
-                    else None
-                )
                 self.slack_service.send_message(
                     channel=channel_id,
                     message=f"Sorry, I encountered an error processing your message: {str(e)}",

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -794,7 +794,7 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
     "slack.thread_replies": SettingDefinition(
         key="slack.thread_replies",
         display_name="Reply in Thread",
-        description="When enabled, Open Assistant replies in a thread under each incoming message instead of posting to the channel root. Useful when multiple users share a channel.",
+        description="When enabled, Open Assistant replies in a thread under each incoming message instead of posting to the channel root — including background sub-task progress updates. Conversation context is also scoped to the thread, so separate threads in a shared channel no longer share history. When disabled, the whole channel shares one conversation.",
         value_type=SettingValueType.BOOL,
         category=ConfigCategory.SLACK,
         default_value=False,

--- a/src/services/message_handler.py
+++ b/src/services/message_handler.py
@@ -112,6 +112,7 @@ class MessageHandler:
         image_mimetype: Optional[str] = None,
         event_callback: Optional[Callable[[dict], Awaitable[None]]] = None,
         pinned_skill: Optional[str] = None,
+        reply_thread_ts: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Handle a user message through the skills-based LLM system.
@@ -129,6 +130,9 @@ class MessageHandler:
             metadata: Optional metadata dict
             image_base64: Optional base64-encoded image data for vision
             image_mimetype: Optional MIME type of the image
+            reply_thread_ts: Optional Slack thread timestamp.  When set,
+                out-of-band progress notifications are posted inside that
+                thread instead of at the channel root.
 
         Returns:
             Dictionary with response, conversation_id, skills_used,
@@ -190,6 +194,7 @@ class MessageHandler:
                     channel=channel,
                     contact_identifier=contact_identifier,
                     event_callback=event_callback,
+                    reply_thread_ts=reply_thread_ts,
                 )
 
             # Step 2: Store user message
@@ -341,6 +346,7 @@ class MessageHandler:
                 plan=plan,
                 channel=channel,
                 contact_identifier=contact_identifier,
+                reply_thread_ts=reply_thread_ts,
                 event_callback=event_callback,
             )
         except Exception as e:
@@ -784,12 +790,18 @@ class MessageHandler:
         channel: str,
         contact_identifier: Optional[str],
         message: str,
+        reply_thread_ts: Optional[str] = None,
     ) -> None:
         """Send a progress notification back to the originating channel.
 
         - whatsapp: sends directly to the contact's phone number.
-        - slack: sends to the channel extracted from the contact_identifier
-          (format ``{channel_id}:{user_id}``).
+        - slack: sends to the channel extracted from the contact_identifier.
+          The Slack contact_identifier is ``{channel_id}`` when "Reply in
+          Thread" is off and ``{channel_id}:{thread_ts}`` when it is on, so
+          taking the part before the first ``:`` yields the channel in both
+          cases.  When *reply_thread_ts* is set the update is posted inside
+          that thread rather than at the channel root, keeping sub-task
+          progress with the exchange that triggered it.
         - webui / subtask / anything else: no-op — the user is watching
           synchronously or it is an internal sub-task.
 
@@ -804,9 +816,12 @@ class MessageHandler:
             elif channel == "slack" and contact_identifier:
                 slack_service = self.tool_executor.services.get("slack")
                 if slack_service:
-                    # contact_identifier is "{channel_id}:{user_id}"
                     slack_channel_id = contact_identifier.split(":")[0]
-                    slack_service.send_message(channel=slack_channel_id, message=message)
+                    slack_service.send_message(
+                        channel=slack_channel_id,
+                        message=message,
+                        thread_ts=reply_thread_ts,
+                    )
             # webui / subtask: user is watching synchronously — no notification needed
         except Exception as exc:
             logger.debug(f"_send_progress_notification ({channel}): {exc}")
@@ -838,6 +853,9 @@ class MessageHandler:
         # originating channel (WhatsApp/Slack) during wait_for_tasks.
         channel: str = "webui",
         contact_identifier: Optional[str] = None,
+        # Slack thread to post progress updates into.  None means post at the
+        # channel root (or the channel has no notion of threads).
+        reply_thread_ts: Optional[str] = None,
         # Resume parameters — when provided, skip message-building preamble
         resume_messages: Optional[List[Dict[str, Any]]] = None,
         resume_iteration: int = 0,
@@ -1434,6 +1452,7 @@ class MessageHandler:
                             channel=channel,
                             contact_identifier=contact_identifier,
                             message=f"⏳ {progress_message}",
+                            reply_thread_ts=reply_thread_ts,
                         )
 
                     # Emit periodic progress while long-running tasks work, so
@@ -1456,6 +1475,7 @@ class MessageHandler:
                                 contact_identifier=contact_identifier,
                                 message=f"⏳ Sub-tasks: {done}/{total} finished, "
                                 f"{counts['running']} still working…",
+                                reply_thread_ts=reply_thread_ts,
                             )
 
                     # Block until all requested tasks finish (or timeout). Tasks
@@ -1486,6 +1506,7 @@ class MessageHandler:
                             channel=channel,
                             contact_identifier=contact_identifier,
                             message=summary,
+                            reply_thread_ts=reply_thread_ts,
                         )
 
                     guidance = ""
@@ -1896,6 +1917,7 @@ class MessageHandler:
         channel: str = "webui",
         contact_identifier: Optional[str] = None,
         event_callback: Optional[Callable[[dict], Awaitable[None]]] = None,
+        reply_thread_ts: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Resume a suspended execution with the user's answer.
 
@@ -1960,6 +1982,7 @@ class MessageHandler:
             plan=plan,
             channel=channel,
             contact_identifier=contact_identifier,
+            reply_thread_ts=reply_thread_ts,
             resume_messages=messages,
             resume_iteration=iteration,
             resume_tools_executed=tools_executed,

--- a/tests/test_slack_thread_scoping.py
+++ b/tests/test_slack_thread_scoping.py
@@ -1,0 +1,156 @@
+"""Tests for Slack thread scoping ("Reply in Thread").
+
+When the toggle is ON, a Slack thread must behave as its own conversation:
+
+* every message the bot sends for that exchange goes into the thread —
+  including out-of-band sub-task progress updates, not just the final reply;
+* the conversation identity carries the ``thread_ts``, so context (and the
+  background sub-tasks keyed off it) stay inside the thread.
+
+When the toggle is OFF the previous channel-wide behaviour is preserved.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.integrations.slack.socket_mode import SlackSocketModeHandler
+from src.services.message_handler import MessageHandler
+
+# ---------------------------------------------------------------------------
+# Progress notifications must honour the thread
+# ---------------------------------------------------------------------------
+
+
+def _handler_with_slack(slack_service):
+    """Build a bare MessageHandler exposing only what the notifier touches."""
+    handler = MessageHandler.__new__(MessageHandler)
+    handler.tool_executor = SimpleNamespace(services={"slack": slack_service})
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_progress_notification_posts_into_thread():
+    slack_service = MagicMock()
+    handler = _handler_with_slack(slack_service)
+
+    await handler._send_progress_notification(
+        channel="slack",
+        contact_identifier="C123:1699999999.000100",
+        message="⏳ Sub-tasks: 1/5 finished, 4 still working…",
+        reply_thread_ts="1699999999.000100",
+    )
+
+    slack_service.send_message.assert_called_once_with(
+        channel="C123",
+        message="⏳ Sub-tasks: 1/5 finished, 4 still working…",
+        thread_ts="1699999999.000100",
+    )
+
+
+@pytest.mark.asyncio
+async def test_progress_notification_posts_at_channel_root_when_not_threaded():
+    slack_service = MagicMock()
+    handler = _handler_with_slack(slack_service)
+
+    await handler._send_progress_notification(
+        channel="slack",
+        contact_identifier="C123",
+        message="⏳ Working…",
+    )
+
+    slack_service.send_message.assert_called_once_with(
+        channel="C123",
+        message="⏳ Working…",
+        thread_ts=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Conversation identity must be thread-scoped only when the toggle is on
+# ---------------------------------------------------------------------------
+
+
+def _socket_handler(thread_replies: bool):
+    """Build a socket-mode handler with stubbed collaborators."""
+    settings_service = MagicMock()
+    settings_service.get_setting.side_effect = lambda key: (
+        thread_replies if key == "slack.thread_replies" else None
+    )
+    settings_service.get_config_with_fallback.return_value = "test-api-key"
+
+    message_handler = MagicMock()
+    message_handler.handle_message = AsyncMock(
+        return_value={
+            "response": "done",
+            "skills_used": [],
+            "tools_executed": [],
+            "iterations": 1,
+        }
+    )
+
+    handler = SlackSocketModeHandler.__new__(SlackSocketModeHandler)
+    handler.message_handler = message_handler
+    handler.slack_service = MagicMock()
+    handler.settings_service = settings_service
+    handler.media_handler = None
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_thread_replies_on_scopes_conversation_to_thread():
+    handler = _socket_handler(thread_replies=True)
+
+    await handler._process_and_reply(
+        channel_id="C123",
+        user_id="U1",
+        text="hello",
+        files=None,
+        thread_ts="1699999999.000100",
+    )
+
+    kwargs = handler.message_handler.handle_message.call_args.kwargs
+    assert kwargs["contact_identifier"] == "C123:1699999999.000100"
+    assert kwargs["reply_thread_ts"] == "1699999999.000100"
+
+    # The final reply lands in the thread too.
+    assert handler.slack_service.send_message.call_args.kwargs["thread_ts"] == ("1699999999.000100")
+
+
+@pytest.mark.asyncio
+async def test_thread_replies_off_preserves_channel_wide_conversation():
+    handler = _socket_handler(thread_replies=False)
+
+    await handler._process_and_reply(
+        channel_id="C123",
+        user_id="U1",
+        text="hello",
+        files=None,
+        thread_ts="1699999999.000100",
+    )
+
+    kwargs = handler.message_handler.handle_message.call_args.kwargs
+    assert kwargs["contact_identifier"] == "C123"
+    assert kwargs["reply_thread_ts"] is None
+    assert handler.slack_service.send_message.call_args.kwargs["thread_ts"] is None
+
+
+@pytest.mark.asyncio
+async def test_separate_threads_get_separate_conversation_identities():
+    """Two threads in one channel must not share a conversation."""
+    handler = _socket_handler(thread_replies=True)
+
+    await handler._process_and_reply(
+        channel_id="C123", user_id="U1", text="a", files=None, thread_ts="111.1"
+    )
+    first = handler.message_handler.handle_message.call_args.kwargs["contact_identifier"]
+
+    await handler._process_and_reply(
+        channel_id="C123", user_id="U2", text="b", files=None, thread_ts="222.2"
+    )
+    second = handler.message_handler.handle_message.call_args.kwargs["contact_identifier"]
+
+    assert first != second
+    assert first == "C123:111.1"
+    assert second == "C123:222.2"


### PR DESCRIPTION
## Summary

When the "Reply in Thread" Slack setting is enabled, each thread now becomes its own isolated conversation with separate context and history. Previously, threads shared channel-wide conversation context. This change ensures that progress notifications and all bot messages for a given exchange stay within the same thread, and conversation identity is scoped to the thread rather than the channel.

## Key Changes

- **Thread-scoped conversation identity**: When "Reply in Thread" is on, the `contact_identifier` now includes the thread timestamp (format: `{channel_id}:{thread_ts}`), making each thread a separate conversation. When off, it remains the bare `channel_id` for backward compatibility.

- **Progress notifications respect thread scope**: The `_send_progress_notification` method now accepts an optional `reply_thread_ts` parameter. Out-of-band progress updates (sub-task status, etc.) are posted into the thread when this is set, keeping all messages for an exchange together.

- **Unified thread resolution**: Both Slack event handlers (`src/api/slack.py` and `src/integrations/slack/socket_mode.py`) now resolve the thread scope once at the start of message processing, ensuring the reply target, progress-notification target, and conversation identity never disagree. This also allows error handlers to reply in-thread consistently.

- **Thread timestamp propagation**: The `reply_thread_ts` parameter is threaded through the message handling pipeline (`handle_message`, `_execute_conversation_loop`, `_resume_suspended_execution`) so all progress notifications use the correct target.

- **Comprehensive test coverage**: New test suite validates that:
  - Progress notifications post into threads when configured
  - Conversation identity is thread-scoped only when the toggle is on
  - Separate threads get separate conversation identities
  - Channel-wide behavior is preserved when the toggle is off

- **Documentation updates**: Clarified that "Reply in Thread" now scopes both visual organization and conversation context to threads, with notes about the behavioral differences when enabled vs. disabled.

## Implementation Details

- The thread scope resolution happens before any message processing, using the `settings_truthy()` helper to check the `slack.thread_replies` setting.
- When `reply_thread_ts` is `None`, the Slack service's `send_message` method receives `thread_ts=None`, posting at the channel root.
- The contact identifier format change (`channel_id` vs. `channel_id:thread_ts`) is handled transparently in progress notification extraction by splitting on the first `:` character.
- Error handlers in both Slack integrations use the pre-computed `reply_thread_ts` value, ensuring errors are also posted in-thread when appropriate.