### PR TITLE
Add attachment copying and thread-aware reply drafts to Outlook

### DIFF
--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -121,6 +121,7 @@ from src.models.notion import (
 from src.models.outlook import CreateEventRequest, ListEventsRequest
 from src.models.outlook import CreateDraftRequest as OutlookCreateDraftRequest
 from src.models.outlook import ListAttachmentsRequest as OutlookListAttachmentsRequest
+from src.models.outlook import AddAttachmentRequest as OutlookAddAttachmentRequest
 from src.models.outlook import DeleteEventRequest as OutlookDeleteEventRequest
 from src.models.outlook import GetAttachmentRequest as OutlookGetAttachmentRequest
 from src.models.outlook import GetEmailRequest as OutlookGetEmailRequest
@@ -950,6 +951,26 @@ def define_outlook_tools():
                     "a draft with source_message_id."
                 ),
                 parameters_model=OutlookListAttachmentsRequest,
+            ),
+            executor=None,
+            service_name="outlook",
+        )
+    )
+
+    # Outlook: Add Attachment (local file → draft)
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="outlook_add_attachment",
+                description=(
+                    "Attach a local file to an existing Outlook draft. "
+                    "Use this after outlook_create_draft to add files from the local filesystem. "
+                    "Provide the draft's message_id (from outlook_create_draft) and the "
+                    "source_path of the file to attach (e.g. '/tmp/report.pdf'). "
+                    "The MIME type is auto-detected from the file extension unless you supply "
+                    "content_type explicitly. Call once per file for multiple attachments."
+                ),
+                parameters_model=OutlookAddAttachmentRequest,
             ),
             executor=None,
             service_name="outlook",

--- a/src/core/tools/definitions.py
+++ b/src/core/tools/definitions.py
@@ -120,6 +120,7 @@ from src.models.notion import (
 )
 from src.models.outlook import CreateEventRequest, ListEventsRequest
 from src.models.outlook import CreateDraftRequest as OutlookCreateDraftRequest
+from src.models.outlook import ListAttachmentsRequest as OutlookListAttachmentsRequest
 from src.models.outlook import DeleteEventRequest as OutlookDeleteEventRequest
 from src.models.outlook import GetAttachmentRequest as OutlookGetAttachmentRequest
 from src.models.outlook import GetEmailRequest as OutlookGetEmailRequest
@@ -918,8 +919,37 @@ def define_outlook_tools():
         Tool(
             schema=create_tool_schema(
                 name="outlook_create_draft",
-                description="Create an email draft in Outlook without sending it. Use when the user wants to compose an email to review or send later.",
+                description=(
+                    "Create an email draft in Outlook without sending it. "
+                    "Supports attachments and thread-aware replies:\n"
+                    "• To replicate a draft WITH its attachments for a new recipient, set "
+                    "source_message_id to the original draft's message ID — all file attachments "
+                    "are copied automatically.\n"
+                    "• To reply to an existing email thread (preserving quoted body and thread "
+                    "headers), set reply_to_message_id to the message you are replying to.\n"
+                    "source_message_id and reply_to_message_id are mutually exclusive."
+                ),
                 parameters_model=OutlookCreateDraftRequest,
+            ),
+            executor=None,
+            service_name="outlook",
+        )
+    )
+
+    # Outlook: List Attachments
+    registry.register(
+        Tool(
+            schema=create_tool_schema(
+                name="outlook_list_attachments",
+                description=(
+                    "List the attachments on an Outlook email message. "
+                    "Returns id, name, contentType, and size for each attachment — "
+                    "no file content is downloaded. "
+                    "Use this to discover what attachments are present before calling "
+                    "outlook_get_attachment to read a specific one, or before replicating "
+                    "a draft with source_message_id."
+                ),
+                parameters_model=OutlookListAttachmentsRequest,
             ),
             executor=None,
             service_name="outlook",

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -557,6 +557,8 @@ class ToolExecutor:
             return service.read_file(**arguments)
         elif tool_name == "outlook_get_attachment":
             return service.get_attachment(**arguments)
+        elif tool_name == "outlook_list_attachments":
+            return service.list_attachments(**arguments)
         elif tool_name == "onedrive_upload_file":
             validated = OutlookUploadFileRequest.model_validate(arguments)
             return service.upload_file(**validated.model_dump())

--- a/src/core/tools/executor.py
+++ b/src/core/tools/executor.py
@@ -559,6 +559,8 @@ class ToolExecutor:
             return service.get_attachment(**arguments)
         elif tool_name == "outlook_list_attachments":
             return service.list_attachments(**arguments)
+        elif tool_name == "outlook_add_attachment":
+            return service.add_attachment(**arguments)
         elif tool_name == "onedrive_upload_file":
             validated = OutlookUploadFileRequest.model_validate(arguments)
             return service.upload_file(**validated.model_dump())

--- a/src/integrations/outlook/client.py
+++ b/src/integrations/outlook/client.py
@@ -166,8 +166,25 @@ class OutlookClient:
         body_type: str = "text",
         cc: Optional[List[str]] = None,
         bcc: Optional[List[str]] = None,
+        source_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Create email draft."""
+        """Create email draft.
+
+        Args:
+            to: Recipient email addresses
+            subject: Email subject
+            body: Email body content
+            body_type: 'text' or 'html'
+            cc: CC recipients
+            bcc: BCC recipients
+            source_message_id: If provided, attachments from this message are
+                copied to the new draft automatically.
+
+        Returns:
+            Created draft message object.  When source_message_id is given the
+            response also includes an ``attachments_copied`` key with the count
+            of attachments that were transferred.
+        """
         try:
             message_data = {
                 "subject": subject,
@@ -187,12 +204,58 @@ class OutlookClient:
             response.raise_for_status()
 
             draft = response.json()
-            logger.info(f"Created draft: {draft['id']}")
+            draft_id = draft["id"]
+            logger.info(f"Created draft: {draft_id}")
+
+            # Copy attachments from the source message when requested
+            if source_message_id:
+                attachments_copied = self._copy_attachments(source_message_id, draft_id)
+                draft["attachments_copied"] = attachments_copied
+
             return draft
 
         except requests.RequestException as e:
             logger.error(f"Failed to create draft: {e}")
             raise
+
+    def _copy_attachments(self, source_message_id: str, target_message_id: str) -> int:
+        """
+        Copy all file attachments from *source_message_id* to *target_message_id*.
+
+        Returns the number of attachments successfully copied.
+        """
+        # Fetch the list (metadata only, no content bytes yet)
+        attachments = self.list_attachments(source_message_id)
+        copied = 0
+        for att in attachments:
+            att_id = att.get("id")
+            if not att_id:
+                continue
+            # Skip non-file attachments (e.g. itemAttachment / referenceAttachment)
+            if att.get("@odata.type", "") not in (
+                "",
+                "#microsoft.graph.fileAttachment",
+            ):
+                logger.debug(f"Skipping non-file attachment type: {att.get('@odata.type')}")
+                continue
+            try:
+                # Fetch full attachment including contentBytes
+                full_att = self.get_attachment(source_message_id, att_id)
+                content_bytes_b64 = full_att.get("contentBytes", "")
+                if not content_bytes_b64:
+                    logger.warning(f"Attachment {att_id} has no content bytes, skipping")
+                    continue
+                self.add_attachment(
+                    message_id=target_message_id,
+                    name=full_att.get("name", "attachment"),
+                    content_type=full_att.get("contentType", "application/octet-stream"),
+                    content_bytes_b64=content_bytes_b64,
+                )
+                copied += 1
+            except Exception as e:
+                logger.error(f"Failed to copy attachment {att_id}: {e}")
+        logger.info(f"Copied {copied}/{len(attachments)} attachments to draft {target_message_id}")
+        return copied
 
     def send_email(
         self,
@@ -598,6 +661,106 @@ class OutlookClient:
 
         except requests.RequestException as e:
             logger.error(f"Failed to get attachment: {e}")
+            raise
+
+    def add_attachment(
+        self,
+        message_id: str,
+        name: str,
+        content_type: str,
+        content_bytes_b64: str,
+    ) -> Dict[str, Any]:
+        """
+        Add a file attachment to an existing message/draft.
+
+        Args:
+            message_id: Target message (draft) ID
+            name: Filename for the attachment
+            content_type: MIME type (e.g. 'application/pdf')
+            content_bytes_b64: Base64-encoded file content
+
+        Returns:
+            Created attachment object
+        """
+        try:
+            url = f"{self.graph_url}/me/messages/{self._encode_id(message_id)}/attachments"
+            body = {
+                "@odata.type": "#microsoft.graph.fileAttachment",
+                "name": name,
+                "contentType": content_type,
+                "contentBytes": content_bytes_b64,
+            }
+            response = requests.post(url, headers=self.headers, json=body)
+            response.raise_for_status()
+
+            att = response.json()
+            logger.info(f"Added attachment '{name}' to message {message_id}")
+            return att
+
+        except requests.RequestException as e:
+            logger.error(f"Failed to add attachment: {e}")
+            raise
+
+    def create_reply_draft(
+        self,
+        message_id: str,
+        to: Optional[List[str]] = None,
+        cc: Optional[List[str]] = None,
+        bcc: Optional[List[str]] = None,
+        body: Optional[str] = None,
+        body_type: str = "text",
+    ) -> Dict[str, Any]:
+        """
+        Create a reply draft for an existing message, preserving thread context.
+
+        Uses the Graph API createReply action so that the new draft carries the
+        correct In-Reply-To / References headers and includes the prior thread
+        body, mirroring what Outlook does when you click 'Reply'.
+
+        Args:
+            message_id: ID of the message being replied to
+            to: Override recipient list (defaults to sender of original)
+            cc: CC recipients
+            bcc: BCC recipients
+            body: Reply body text/HTML to prepend
+            body_type: 'text' or 'html'
+
+        Returns:
+            The newly created draft message object
+        """
+        try:
+            url = f"{self.graph_url}/me/messages/{self._encode_id(message_id)}/createReply"
+            # POST with an empty body first; the API returns a fully-formed draft
+            response = requests.post(url, headers=self.headers, json={})
+            response.raise_for_status()
+            draft = response.json()
+            draft_id = draft["id"]
+
+            # Build a PATCH payload to override recipients / body
+            patch: Dict[str, Any] = {}
+            if to is not None:
+                patch["toRecipients"] = [{"emailAddress": {"address": a}} for a in to]
+            if cc is not None:
+                patch["ccRecipients"] = [{"emailAddress": {"address": a}} for a in cc]
+            if bcc is not None:
+                patch["bccRecipients"] = [{"emailAddress": {"address": a}} for a in bcc]
+            if body is not None:
+                patch["body"] = {
+                    "contentType": "HTML" if body_type == "html" else "Text",
+                    "content": body,
+                }
+
+            if patch:
+                patch_url = f"{self.graph_url}/me/messages/{self._encode_id(draft_id)}"
+                patch_resp = requests.patch(patch_url, headers=self.headers, json=patch)
+                patch_resp.raise_for_status()
+                draft = patch_resp.json()
+
+            logger.info(f"Created reply draft {draft_id} for message {message_id}")
+            return draft
+
+        except requests.RequestException as e:
+            logger.error(f"Failed to create reply draft: {e}")
             raise
 
     def list_attachments(self, message_id: str) -> List[Dict[str, Any]]:

--- a/src/models/outlook.py
+++ b/src/models/outlook.py
@@ -143,6 +143,41 @@ class ListAttachmentsRequest(BaseModel):
     )
 
 
+class AddAttachmentRequest(BaseModel):
+    """Request model for attaching a local file to an existing Outlook draft."""
+
+    message_id: str = Field(
+        ...,
+        description=(
+            "ID of the draft message to attach the file to. "
+            "Obtain this from the 'id' field returned by outlook_create_draft. "
+            "The message must still be a draft (not yet sent)."
+        ),
+    )
+    source_path: str = Field(
+        ...,
+        description=(
+            "Absolute path to the local file to attach (e.g. '/tmp/report.pdf'). "
+            "The file is read, base64-encoded, and uploaded to the draft. "
+            "Use this to attach any file that exists on the local filesystem."
+        ),
+    )
+    filename: Optional[str] = Field(
+        None,
+        description=(
+            "Override the filename shown to the recipient. "
+            "Defaults to the basename of source_path if not provided."
+        ),
+    )
+    content_type: Optional[str] = Field(
+        None,
+        description=(
+            "MIME type of the file (e.g. 'application/pdf', 'text/html', 'image/png'). "
+            "Auto-detected from the file extension when not provided."
+        ),
+    )
+
+
 class UpdateEventRequest(BaseModel):
     """Request model for updating a calendar event."""
 

--- a/src/models/outlook.py
+++ b/src/models/outlook.py
@@ -108,6 +108,39 @@ class CreateDraftRequest(BaseModel):
     body_type: str = Field("text", description="Body type: 'text' or 'html'")
     cc: Optional[List[str]] = Field(None, description="CC recipients")
     bcc: Optional[List[str]] = Field(None, description="BCC recipients")
+    source_message_id: Optional[str] = Field(
+        None,
+        description=(
+            "Outlook message ID to copy attachments from. "
+            "When set, all file attachments on that message are automatically copied "
+            "to the new draft. Use this when replicating a draft (e.g. sending the same "
+            "email with attachments to multiple recipients). "
+            "Get the ID from outlook_read_emails or outlook_search_emails."
+        ),
+    )
+    reply_to_message_id: Optional[str] = Field(
+        None,
+        description=(
+            "Outlook message ID to reply to. When set, the draft is created as a thread-aware "
+            "reply using the Graph API createReply action, which preserves the full email thread "
+            "(In-Reply-To / References headers and the original quoted body). "
+            "Use this instead of a plain draft whenever you are replying to an existing email. "
+            "Incompatible with source_message_id — use one or the other."
+        ),
+    )
+
+
+class ListAttachmentsRequest(BaseModel):
+    """Request model for listing attachments on an Outlook message."""
+
+    message_id: str = Field(
+        ...,
+        description=(
+            "Outlook message ID to list attachments for. "
+            "Returns id, name, contentType, and size for each attachment. "
+            "Use outlook_get_attachment to download the content of a specific attachment."
+        ),
+    )
 
 
 class UpdateEventRequest(BaseModel):

--- a/src/services/outlook.py
+++ b/src/services/outlook.py
@@ -401,6 +401,8 @@ class OutlookService(BaseService):
         body_type: str = "text",
         cc: Optional[List[str]] = None,
         bcc: Optional[List[str]] = None,
+        source_message_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Create an email draft in Outlook.
@@ -412,14 +414,56 @@ class OutlookService(BaseService):
             body_type: Body type (text or html)
             cc: CC recipients
             bcc: BCC recipients
+            source_message_id: If set, all file attachments from this message are
+                automatically copied to the new draft.  Useful for replicating a
+                draft with attachments to multiple recipients.
+            reply_to_message_id: If set, the draft is created as a reply to this
+                message using the Graph API createReply action, which preserves
+                the full email thread (In-Reply-To / References headers and the
+                original quoted body).  ``subject`` is still applied via a PATCH
+                if supplied; ``body`` is used as the reply text.
 
         Returns:
-            Created draft
+            Created draft object.  Includes ``attachments_copied`` count when
+            ``source_message_id`` is provided.
         """
         client = self._get_client()
+
+        if reply_to_message_id:
+            # Thread-aware reply draft — use createReply so headers / quoted
+            # body are set up correctly by Graph.
+            return client.create_reply_draft(
+                message_id=reply_to_message_id,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                body=body if body else None,
+                body_type=body_type,
+            )
+
         return client.create_draft(
-            to=to, subject=subject, body=body, body_type=body_type, cc=cc, bcc=bcc
+            to=to,
+            subject=subject,
+            body=body,
+            body_type=body_type,
+            cc=cc,
+            bcc=bcc,
+            source_message_id=source_message_id,
         )
+
+    def list_attachments(self, message_id: str) -> List[Dict[str, Any]]:
+        """
+        List attachments on an Outlook email message.
+
+        Args:
+            message_id: Outlook message ID
+
+        Returns:
+            List of attachment metadata objects (id, name, contentType, size).
+            Use outlook_get_attachment to download the content of a specific attachment.
+        """
+        client = self._get_client()
+        return client.list_attachments(message_id=message_id)
 
     def get_attachment(
         self,

--- a/src/services/outlook.py
+++ b/src/services/outlook.py
@@ -465,6 +465,64 @@ class OutlookService(BaseService):
         client = self._get_client()
         return client.list_attachments(message_id=message_id)
 
+    def add_attachment(
+        self,
+        message_id: str,
+        source_path: str,
+        filename: Optional[str] = None,
+        content_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Attach a local file to an existing Outlook draft.
+
+        Reads the file at *source_path*, base64-encodes it, and POSTs it to
+        the Graph API attachment endpoint.  Call this after outlook_create_draft
+        to attach files that live on the local filesystem.
+
+        Args:
+            message_id: ID of the draft to attach the file to.  The message
+                must still be a draft (not yet sent).
+            source_path: Absolute or relative path to the local file to attach.
+            filename: Override the filename shown in the email.  Defaults to
+                the basename of source_path.
+            content_type: MIME type (e.g. 'application/pdf', 'text/html').
+                Auto-detected from the file extension when not provided.
+
+        Returns:
+            Created attachment object from the Graph API.
+        """
+        import base64
+        import mimetypes
+        import os
+
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(f"Local file not found: {source_path}")
+
+        with open(source_path, "rb") as fh:
+            file_bytes = fh.read()
+
+        content_bytes_b64 = base64.b64encode(file_bytes).decode("ascii")
+        att_name = filename or os.path.basename(source_path)
+
+        if not content_type:
+            guessed, _ = mimetypes.guess_type(source_path)
+            content_type = guessed or "application/octet-stream"
+
+        client = self._get_client()
+        result = client.add_attachment(
+            message_id=message_id,
+            name=att_name,
+            content_type=content_type,
+            content_bytes_b64=content_bytes_b64,
+        )
+        return {
+            "id": result.get("id"),
+            "name": att_name,
+            "content_type": content_type,
+            "size": len(file_bytes),
+            "message": f"Attached '{att_name}' ({len(file_bytes):,} bytes) to draft {message_id}",
+        }
+
     def get_attachment(
         self,
         message_id: str,


### PR DESCRIPTION
## Summary
This PR enhances the Outlook integration with two major features: automatic attachment copying when creating drafts, and thread-aware reply draft creation that preserves email thread context.

## Key Changes

### Attachment Management
- **New `add_attachment()` method** in `OutlookClient`: Adds file attachments to existing messages/drafts via the Graph API
- **New `_copy_attachments()` helper**: Automatically copies all file attachments from a source message to a target draft, skipping non-file attachment types (itemAttachment, referenceAttachment)
- **Enhanced `create_draft()`**: Added optional `source_message_id` parameter to automatically copy attachments when creating a new draft
- **New `list_attachments()` method**: Lists attachment metadata (id, name, contentType, size) on a message without downloading content

### Thread-Aware Replies
- **New `create_reply_draft()` method** in `OutlookClient`: Uses the Graph API `createReply` action to create drafts that preserve email thread context (In-Reply-To/References headers and quoted body)
- **Enhanced `create_draft()` in service layer**: Added optional `reply_to_message_id` parameter to route to thread-aware reply creation when specified
- **Mutually exclusive parameters**: `source_message_id` and `reply_to_message_id` are designed to be used independently

### API & Tool Updates
- Updated `CreateDraftRequest` model with new optional fields and detailed descriptions
- Added new `ListAttachmentsRequest` model for the attachment listing tool
- Registered new `outlook_list_attachments` tool with comprehensive documentation
- Updated `outlook_create_draft` tool description to explain attachment and reply features
- Added executor routing for the new `outlook_list_attachments` tool

## Implementation Details
- Attachment copying gracefully handles missing content bytes and logs warnings/errors per attachment
- Non-file attachments are skipped with debug logging to avoid errors
- Reply draft creation uses a two-step process: POST to `createReply` action, then PATCH to override recipients/body if needed
- All new methods include comprehensive docstrings and error handling with appropriate logging