### PR TITLE
Add /cancel command to stop running tasks and clear suspended state

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,3 +33,52 @@ A good rule of thumb: one thread, one topic. When the topic changes, `/clear`.
 ### What happens under the hood
 
 `/clear` creates a brand-new conversation with a fresh ID and routes all subsequent messages to it. The previous conversation is **not deleted** — it remains fully available in your conversation history and can be searched or referenced by the assistant's memory tools.
+
+---
+
+## `/cancel`
+
+Stop all ongoing work in the current conversation and return to a clean state — without leaving the thread.
+
+```
+/cancel
+```
+
+**Response**: `⛔ All ongoing work has been stopped. You can start a new request whenever you're ready.`  
+(If background tasks were running, the response also lists how many were cancelled and their IDs.)
+
+### Why use it
+
+Open Assistant can run long multi-step plans and dispatch parallel background tasks on your behalf. Most of the time this is exactly what you want — but occasionally the model gets stuck in a loop, pursues the wrong approach, or you simply change your mind mid-flight.
+
+- **Loop detected too late.** The built-in stuck-detection kicks in automatically, but it takes a few repeated iterations to trigger. `/cancel` lets you cut it short the moment you notice something is off.
+- **Wrong plan, wrong direction.** If the model misunderstood the request and is off on a long tangent, waiting for it to finish wastes time and tokens.
+- **Background tasks you no longer need.** `dispatch_task` spawns sub-tasks that run concurrently. `/cancel` stops all of them for the current conversation immediately.
+- **Suspended `ask_user` prompts.** If the model paused mid-plan to ask you a question but you want to start fresh instead of answering, `/cancel` clears that suspended state.
+
+### When to use it
+
+Use `/cancel` when:
+
+- The assistant appears stuck — repeating the same tool calls or making no visible progress.
+- You realise mid-response that you phrased the request wrong and want to try again.
+- A multi-step plan is running but you want to change course before it finishes.
+- You see background tasks spinning (the tool-call indicator keeps appearing) and want them stopped.
+
+### Difference from `/clear`
+
+| | `/cancel` | `/clear` |
+|---|---|---|
+| Stops ongoing work | ✅ Yes | ✅ Only because a new conversation is started |
+| Stays in the same thread | ✅ Yes | ❌ No — starts a new conversation |
+| Preserves conversation history | ✅ Yes | ✅ Yes (old thread is kept, a new one begins) |
+| Use when… | You want to interrupt and retry **in the same thread** | You are switching to a **different topic** entirely |
+
+### What happens under the hood
+
+When you type `/cancel`:
+
+1. Every running background sub-task for the active conversation has its asyncio future cancelled and is marked `"cancelled"` in the task store.
+2. Any suspended `ask_user` execution state is cleared, so the next message you send is treated as a fresh request rather than an answer to a previous question.
+3. Both the `/cancel` command and the assistant's acknowledgement are stored in the conversation history, keeping the thread coherent.
+4. The response is returned immediately — no LLM call is made.

--- a/src/services/async_task_dispatcher.py
+++ b/src/services/async_task_dispatcher.py
@@ -260,6 +260,33 @@ class AsyncTaskDispatcher:
             if t.conversation_id == conversation_id and t.status == "running"
         ]
 
+    def cancel_all_for_conversation(self, conversation_id: str) -> List[str]:
+        """Cancel every running sub-task that belongs to *conversation_id*.
+
+        Each in-flight asyncio.Task is cancelled (best-effort) and the
+        :class:`AsyncTask` record is immediately marked ``"cancelled"`` so
+        callers don't have to wait for the asyncio cancellation to propagate.
+
+        Args:
+            conversation_id: The parent conversation whose tasks should stop.
+
+        Returns:
+            List of *task_id* strings that were cancelled.
+        """
+        cancelled_ids: List[str] = []
+        for task in self._tasks.values():
+            if task.conversation_id == conversation_id and task.status == "running":
+                if task._asyncio_task is not None and not task._asyncio_task.done():
+                    task._asyncio_task.cancel()
+                task.status = "cancelled"
+                task.error = "Cancelled by /cancel command."
+                task.completed_at = datetime.now(timezone.utc)
+                task.reported = True
+                cancelled_ids.append(task.task_id)
+                self._persist_final(task)
+                logger.info(f"Cancelled sub-task {task.task_id} for conversation {conversation_id}")
+        return cancelled_ids
+
     async def wait_for(
         self,
         task_ids: List[str],

--- a/src/services/message_handler.py
+++ b/src/services/message_handler.py
@@ -189,9 +189,7 @@ class MessageHandler:
                     content=response_text,
                     metadata={"cancelled_tasks": cancelled},
                 )
-                logger.info(
-                    f"/cancel: stopped {n} task(s) in conversation {conv_id}: {cancelled}"
-                )
+                logger.info(f"/cancel: stopped {n} task(s) in conversation {conv_id}: {cancelled}")
                 return {
                     "response": response_text,
                     "conversation_id": conv_id,

--- a/src/services/message_handler.py
+++ b/src/services/message_handler.py
@@ -157,7 +157,53 @@ class MessageHandler:
             conv_id = conversation["conversation_id"]
             logger.debug(f"Conversation ID: {conv_id}")
 
-            # Step 1b: Handle /clear command — start a fresh conversation,
+            # Step 1b: Handle /cancel command — stop all running threads,
+            # clear any suspended ask_user state, and let the user continue
+            # in the same conversation from a clean slate.
+            if message.strip() == "/cancel":
+                cancelled = self.async_task_dispatcher.cancel_all_for_conversation(conv_id)
+                # Clear any suspended ask_user state so the next message is
+                # treated as a fresh request rather than a resumed execution.
+                self._clear_suspended_state(conv_id)
+                n = len(cancelled)
+                if n:
+                    cancel_note = (
+                        f"Cancelled {n} background task{'s' if n != 1 else ''} "
+                        f"({', '.join(cancelled)}). "
+                    )
+                else:
+                    cancel_note = ""
+                response_text = (
+                    f"⛔ {cancel_note}All ongoing work has been stopped. "
+                    "You can start a new request whenever you're ready."
+                )
+                self.conversation_service.add_message(
+                    conversation_id=conv_id,
+                    role="user",
+                    content=message,
+                    metadata={"source": "cancel_command"},
+                )
+                self.conversation_service.add_message(
+                    conversation_id=conv_id,
+                    role="assistant",
+                    content=response_text,
+                    metadata={"cancelled_tasks": cancelled},
+                )
+                logger.info(
+                    f"/cancel: stopped {n} task(s) in conversation {conv_id}: {cancelled}"
+                )
+                return {
+                    "response": response_text,
+                    "conversation_id": conv_id,
+                    "skills_used": [],
+                    "tools_executed": [],
+                    "iterations": 0,
+                    "stuck_detected": False,
+                    "cancelled": True,
+                    "cancelled_tasks": cancelled,
+                }
+
+            # Step 1c: Handle /clear command — start a fresh conversation,
             # leaving the existing one intact as history.
             if message.strip() == "/clear":
                 new_conv_id = str(uuid4())
@@ -180,7 +226,7 @@ class MessageHandler:
                     "cleared": True,
                 }
 
-            # Step 1c: Check for suspended execution (ask_user resumption)
+            # Step 1d: Check for suspended execution (ask_user resumption)
             suspended_result = self._get_suspended_state(conv_id)
             if suspended_result:
                 suspended_state, suspended_msg_id = suspended_result
@@ -1889,6 +1935,40 @@ class MessageHandler:
         except Exception as e:
             logger.warning(f"Could not check for suspended state: {e}")
         return None
+
+    def _clear_suspended_state(self, conversation_id: str) -> bool:
+        """Clear any suspended ask_user state for *conversation_id*.
+
+        Replaces the ``suspended_state`` key in the most-recent suspended
+        message's metadata with ``{"cancelled": True}`` so that subsequent
+        messages are treated as fresh requests rather than resumed executions.
+
+        Returns True if a suspended state was found and cleared, False otherwise.
+        """
+        try:
+            history = self.conversation_service.message_repo.get_recent_messages(
+                conversation_id, count=5
+            )
+            if not history:
+                return False
+            for msg in reversed(history):
+                meta = msg.get("metadata")
+                if isinstance(meta, str):
+                    try:
+                        meta = json.loads(meta)
+                    except (json.JSONDecodeError, TypeError):
+                        meta = None
+                if isinstance(meta, dict) and meta.get("suspended_state"):
+                    msg_id = msg.get("message_id", "")
+                    if msg_id:
+                        self.conversation_service.message_repo.update_metadata(
+                            msg_id, {"cancelled": True}
+                        )
+                        logger.info(f"Cleared suspended state for conversation {conversation_id}")
+                    return True
+        except Exception as e:
+            logger.warning(f"Could not clear suspended state: {e}")
+        return False
 
     def _save_suspended_state(
         self, conversation_id: str, suspended_state: Dict[str, Any], question: str = ""

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -455,6 +455,122 @@
             text-decoration: line-through;
             opacity: 0.7;
         }
+
+        /* ── Cancel button ──────────────────────────────────────── */
+        .cancel-btn {
+            padding: 12px 18px;
+            background: rgba(239, 68, 68, 0.1);
+            color: #ef4444;
+            border: 2px solid #ef4444;
+            border-radius: 24px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            white-space: nowrap;
+        }
+
+        .cancel-btn:hover {
+            background: rgba(239, 68, 68, 0.22);
+            box-shadow: 0 0 10px rgba(239, 68, 68, 0.4);
+            transform: translateY(-1px);
+        }
+
+        /* ── Confirmation modal ─────────────────────────────────── */
+        .modal-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.65);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            backdrop-filter: blur(3px);
+            animation: fadeIn 0.15s ease-out;
+        }
+
+        .modal-overlay.hidden {
+            display: none;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to   { opacity: 1; }
+        }
+
+        .modal-card {
+            background: var(--card-background);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 28px 32px;
+            max-width: 380px;
+            width: 90%;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+            animation: slideUp 0.18s ease-out;
+        }
+
+        @keyframes slideUp {
+            from { opacity: 0; transform: translateY(16px); }
+            to   { opacity: 1; transform: translateY(0);    }
+        }
+
+        .modal-icon {
+            font-size: 2rem;
+            margin-bottom: 12px;
+        }
+
+        .modal-title {
+            font-size: 1.15rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .modal-body {
+            font-size: 0.92rem;
+            color: var(--text-secondary);
+            line-height: 1.55;
+            margin-bottom: 24px;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 10px;
+            justify-content: flex-end;
+        }
+
+        .modal-btn-secondary {
+            padding: 9px 18px;
+            background: transparent;
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            font-size: 0.9rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .modal-btn-secondary:hover {
+            background: var(--background-color);
+            color: var(--text-primary);
+        }
+
+        .modal-btn-danger {
+            padding: 9px 18px;
+            background: rgba(239, 68, 68, 0.12);
+            color: #ef4444;
+            border: 1px solid #ef4444;
+            border-radius: 8px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .modal-btn-danger:hover {
+            background: rgba(239, 68, 68, 0.25);
+            box-shadow: 0 0 8px rgba(239, 68, 68, 0.35);
+        }
     </style>
 </head>
 <body>
@@ -537,8 +653,25 @@
                         rows="1"
                         autocomplete="off"
                     ></textarea>
+                    <button id="cancelButton" class="cancel-btn" hidden title="Stop ongoing work">⛔ Stop</button>
                     <button id="sendButton">Send</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Cancel confirmation modal -->
+    <div class="modal-overlay hidden" id="cancelModal" role="dialog" aria-modal="true" aria-labelledby="cancelModalTitle">
+        <div class="modal-card">
+            <div class="modal-icon">⛔</div>
+            <div class="modal-title" id="cancelModalTitle">Stop ongoing work?</div>
+            <div class="modal-body">
+                This will cancel all background tasks for this conversation.
+                You can send a new request straight away.
+            </div>
+            <div class="modal-actions">
+                <button class="modal-btn-secondary" id="cancelModalDismiss">Keep waiting</button>
+                <button class="modal-btn-danger" id="cancelModalConfirm">Yes, stop it</button>
             </div>
         </div>
     </div>

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -653,7 +653,7 @@
                         rows="1"
                         autocomplete="off"
                     ></textarea>
-                    <button id="cancelButton" class="cancel-btn" hidden title="Stop ongoing work">⛔ Stop</button>
+                    <button id="cancelButton" class="cancel-btn" hidden title="Stop ongoing work">Stop</button>
                     <button id="sendButton">Send</button>
                 </div>
             </div>

--- a/src/ui/static/js/chat.js
+++ b/src/ui/static/js/chat.js
@@ -3,10 +3,15 @@
 let conversationId = storage.get('current_conversation_id');
 let conversationHistory = [];
 
+// Tracks the AbortController for the active SSE stream so the cancel button
+// can tear it down immediately without waiting for the LLM to finish.
+let activeStreamAbortController = null;
+
 // DOM Elements
 const chatMessages = document.getElementById('chatMessages');
 const messageInput = document.getElementById('messageInput');
 const sendButton = document.getElementById('sendButton');
+const cancelButton = document.getElementById('cancelButton');
 const newConversationBtn = document.getElementById('newConversationBtn');
 const conversationIdDisplay = document.getElementById('conversationIdDisplay');
 const toggleSidebarBtn = document.getElementById('toggleSidebarBtn');
@@ -15,6 +20,9 @@ const chatLayout = document.getElementById('chatLayout');
 const conversationSearch = document.getElementById('conversationSearch');
 const dateFilter = document.getElementById('dateFilter');
 const loadMoreBtn = document.getElementById('loadMoreConversations');
+const cancelModal = document.getElementById('cancelModal');
+const cancelModalDismiss = document.getElementById('cancelModalDismiss');
+const cancelModalConfirm = document.getElementById('cancelModalConfirm');
 
 // Initialize
 function init() {
@@ -81,6 +89,67 @@ function displayIntegrationStatus(status) {
     }
 }
 
+// Switch the input area into "streaming" mode: disable send, show cancel button.
+function setStreamingState(streaming) {
+    sendButton.hidden = streaming;
+    sendButton.disabled = streaming;
+    cancelButton.hidden = !streaming;
+    messageInput.disabled = streaming;
+}
+
+// Show / hide the cancel confirmation modal.
+function showCancelModal() {
+    cancelModal.classList.remove('hidden');
+    cancelModalConfirm.focus();
+}
+
+function hideCancelModal() {
+    cancelModal.classList.add('hidden');
+}
+
+// Abort the live SSE stream and send /cancel to the backend so server-side
+// tasks are also stopped.  Called when the user confirms the cancel modal.
+async function executeCancel() {
+    hideCancelModal();
+
+    // 1. Tear down the live SSE connection immediately.
+    if (activeStreamAbortController) {
+        activeStreamAbortController.abort();
+        activeStreamAbortController = null;
+    }
+
+    // 2. Snap the UI back to idle right away — don't wait for the backend.
+    hideTypingIndicator();
+    setStreamingState(false);
+
+    // 3. Tell the backend to stop all running tasks; display the acknowledgement.
+    try {
+        const base = window.INSTANCE_BASE_PATH || '';
+        const result = await fetch(base + '/api/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                message: '/cancel',
+                conversation_id: conversationId,
+                channel: 'webui',
+            }),
+        });
+        if (result.ok) {
+            const data = await result.json();
+            if (data.conversation_id) {
+                conversationId = data.conversation_id;
+                storage.set('current_conversation_id', conversationId);
+                updateConversationDisplay();
+            }
+            addMessageToUI(data.response, 'assistant');
+        }
+    } catch (_) {
+        // Non-critical — the stream was already aborted; the UI is already clean.
+    }
+
+    messageInput.focus();
+}
+
 // Setup event listeners
 function setupEventListeners() {
     sendButton.addEventListener('click', sendMessage);
@@ -90,6 +159,33 @@ function setupEventListeners() {
             sendMessage();
         }
     });
+
+    // Cancel button → show confirmation modal.
+    if (cancelButton) {
+        cancelButton.addEventListener('click', showCancelModal);
+    }
+
+    // Modal buttons.
+    if (cancelModalDismiss) {
+        cancelModalDismiss.addEventListener('click', hideCancelModal);
+    }
+    if (cancelModalConfirm) {
+        cancelModalConfirm.addEventListener('click', executeCancel);
+    }
+
+    // Pressing Escape closes the modal without cancelling.
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !cancelModal.classList.contains('hidden')) {
+            hideCancelModal();
+        }
+    });
+
+    // Clicking the dark overlay (outside the card) also dismisses.
+    if (cancelModal) {
+        cancelModal.addEventListener('click', (e) => {
+            if (e.target === cancelModal) hideCancelModal();
+        });
+    }
 
     if (newConversationBtn) {
         newConversationBtn.addEventListener('click', startNewConversation);
@@ -161,23 +257,30 @@ async function sendMessage() {
     addMessageToUI(message, 'user');
     messageInput.value = '';
 
-    messageInput.disabled = true;
-    sendButton.disabled = true;
+    setStreamingState(true);
     showTypingIndicator();
 
     // Streaming path (modern browsers)
     if (typeof ReadableStream !== 'undefined' && typeof TextDecoder !== 'undefined') {
+        let aborted = false;
         try {
             await sendMessageStreaming(message);
         } catch (error) {
-            hideTypingIndicator();
-            console.error('Streaming error:', error);
-            toast.error(error.message || 'Failed to get response');
-            addMessageToUI('Sorry, I encountered an error. Please try again.', 'error');
+            if (error.name === 'AbortError') {
+                // User-initiated cancel — the UI is already cleaned up by executeCancel();
+                // swallow the error silently.
+                aborted = true;
+            } else {
+                hideTypingIndicator();
+                console.error('Streaming error:', error);
+                toast.error(error.message || 'Failed to get response');
+                addMessageToUI('Sorry, I encountered an error. Please try again.', 'error');
+            }
         } finally {
-            messageInput.disabled = false;
-            sendButton.disabled = false;
-            messageInput.focus();
+            if (!aborted) {
+                setStreamingState(false);
+                messageInput.focus();
+            }
         }
         return;
     }
@@ -206,14 +309,18 @@ async function sendMessage() {
         toast.error(error.message || 'Failed to get response');
         addMessageToUI('Sorry, I encountered an error. Please try again.', 'error');
     } finally {
-        messageInput.disabled = false;
-        sendButton.disabled = false;
+        setStreamingState(false);
         messageInput.focus();
     }
 }
 
 async function sendMessageStreaming(message) {
     const base = window.INSTANCE_BASE_PATH || '';
+
+    // Create a fresh AbortController for this stream so the cancel button can
+    // tear it down without navigating away or showing an error.
+    activeStreamAbortController = new AbortController();
+
     const resp = await fetch(base + '/api/chat/stream', {
         method: 'POST',
         redirect: 'manual',
@@ -222,7 +329,8 @@ async function sendMessageStreaming(message) {
             message: message,
             conversation_id: conversationId,
             channel: 'webui'
-        })
+        }),
+        signal: activeStreamAbortController.signal,
     });
 
     // Auth gateway returns 302 on expired sessions; fetch follows it converting
@@ -293,6 +401,7 @@ async function sendMessageStreaming(message) {
                 }
 
             } else if (event.type === 'complete') {
+                activeStreamAbortController = null;
                 hideTypingIndicator();
                 if (event.conversation_id) {
                     conversationId = event.conversation_id;
@@ -304,17 +413,12 @@ async function sendMessageStreaming(message) {
                 if (chatLayout.classList.contains('sidebar-open')) {
                     historyManager.loadConversations(false);
                 }
-                messageInput.disabled = false;
-                sendButton.disabled = false;
-                messageInput.focus();
 
             } else if (event.type === 'error') {
+                activeStreamAbortController = null;
                 hideTypingIndicator();
                 toast.error(event.error || 'Failed to get response');
                 addMessageToUI('Sorry, I encountered an error. Please try again.', 'error');
-                messageInput.disabled = false;
-                sendButton.disabled = false;
-                messageInput.focus();
             }
         }
     }

--- a/tests/test_cancel_command.py
+++ b/tests/test_cancel_command.py
@@ -11,13 +11,11 @@ Covers:
 
 import asyncio
 import json
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from src.services.async_task_dispatcher import AsyncTaskDispatcher
-
 
 # ---------------------------------------------------------------------------
 # AsyncTaskDispatcher.cancel_all_for_conversation
@@ -111,9 +109,7 @@ def _make_handler():
     skill_repo.get_enabled_skills.return_value = []
 
     conversation_service = MagicMock()
-    conversation_service.create_or_get_conversation.return_value = {
-        "conversation_id": "conv-test"
-    }
+    conversation_service.create_or_get_conversation.return_value = {"conversation_id": "conv-test"}
     conversation_service.add_message.return_value = {"message_id": "msg-1"}
     conversation_service.message_repo = MagicMock()
     conversation_service.message_repo.get_recent_messages.return_value = []

--- a/tests/test_cancel_command.py
+++ b/tests/test_cancel_command.py
@@ -1,0 +1,273 @@
+"""Tests for the /cancel slash command.
+
+Covers:
+- AsyncTaskDispatcher.cancel_all_for_conversation — cancels asyncio tasks and
+  marks records as "cancelled".
+- MessageHandler /cancel branch — returns a clean response, records the command
+  in the conversation, and cancels running sub-tasks.
+- MessageHandler._clear_suspended_state — removes an ask_user suspension so the
+  next message is treated as a fresh request.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.async_task_dispatcher import AsyncTaskDispatcher
+
+
+# ---------------------------------------------------------------------------
+# AsyncTaskDispatcher.cancel_all_for_conversation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_stops_running_tasks():
+    """Running sub-tasks for the given conversation are cancelled."""
+
+    started = asyncio.Event()
+
+    async def slow_handler(message, channel="subtask", pinned_skill=None, **kw):
+        started.set()
+        await asyncio.sleep(10)  # long-running — must be cancelled
+        return {"response": "should not reach here", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(slow_handler)
+    tid = d.dispatch("long job", conversation_id="conv-1")
+    await started.wait()  # ensure the task is actually running
+
+    cancelled = d.cancel_all_for_conversation("conv-1")
+
+    assert cancelled == [tid]
+    assert d._tasks[tid].status == "cancelled"
+    assert "cancelled" in d._tasks[tid].error.lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_ignores_other_conversations():
+    """Sub-tasks from a different conversation must not be affected."""
+
+    started = asyncio.Event()
+
+    async def slow_handler(message, channel="subtask", pinned_skill=None, **kw):
+        started.set()
+        await asyncio.sleep(10)
+        return {"response": "ok", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(slow_handler)
+    tid = d.dispatch("other conv task", conversation_id="conv-OTHER")
+    await started.wait()
+
+    cancelled = d.cancel_all_for_conversation("conv-MINE")
+    assert cancelled == []
+    # The unrelated task is still running (or finished on its own)
+    assert d._tasks[tid].status in ("running", "completed")
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_skips_already_finished_tasks():
+    """Completed or failed tasks are not included in the cancellation list."""
+
+    async def instant_handler(message, channel="subtask", pinned_skill=None, **kw):
+        return {"response": "done", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(instant_handler)
+    tid = d.dispatch("fast task", conversation_id="conv-1")
+
+    # Wait for the task to finish before calling cancel.
+    await asyncio.wait_for(d.wait_for([tid], timeout=2), timeout=5)
+
+    cancelled = d.cancel_all_for_conversation("conv-1")
+    assert tid not in cancelled
+    assert d._tasks[tid].status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_returns_empty_when_no_tasks():
+    """cancel_all_for_conversation returns an empty list when nothing is running."""
+
+    async def handler(message, **kw):
+        return {"response": "ok", "tools_executed": []}
+
+    d = AsyncTaskDispatcher(handler)
+    result = d.cancel_all_for_conversation("conv-empty")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# MessageHandler /cancel command
+# ---------------------------------------------------------------------------
+
+
+def _make_handler():
+    """Return a minimal MessageHandler-like object with mocked dependencies."""
+    from src.services.message_handler import MessageHandler
+
+    skill_repo = MagicMock()
+    skill_repo.get_skills_by_keywords.return_value = []
+    skill_repo.get_enabled_skills.return_value = []
+
+    conversation_service = MagicMock()
+    conversation_service.create_or_get_conversation.return_value = {
+        "conversation_id": "conv-test"
+    }
+    conversation_service.add_message.return_value = {"message_id": "msg-1"}
+    conversation_service.message_repo = MagicMock()
+    conversation_service.message_repo.get_recent_messages.return_value = []
+    conversation_service.conversation_repo = MagicMock()
+    conversation_service.conversation_repo.get_by_id.return_value = None
+
+    memory_service = MagicMock()
+    memory_service.prompts_repo = MagicMock()
+    memory_service.prompts_repo.get_value.return_value = ""
+
+    settings_service = MagicMock()
+    settings_service.get_config_with_fallback.return_value = False
+    settings_service.settings_repo = MagicMock()
+
+    tool_executor = MagicMock()
+
+    handler = MessageHandler(
+        skill_repo=skill_repo,
+        conversation_service=conversation_service,
+        memory_service=memory_service,
+        settings_service=settings_service,
+        tool_executor=tool_executor,
+    )
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_returns_cancelled_flag():
+    """/cancel returns a result dict with cancelled=True."""
+    handler = _make_handler()
+
+    result = await handler.handle_message(
+        message="/cancel",
+        conversation_id="conv-test",
+        channel="webui",
+    )
+
+    assert result["cancelled"] is True
+    assert result["conversation_id"] == "conv-test"
+    assert result["iterations"] == 0
+    assert result["stuck_detected"] is False
+    assert "stopped" in result["response"].lower() or "cancelled" in result["response"].lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_stores_messages_in_conversation():
+    """/cancel writes both user and assistant messages to the conversation."""
+    handler = _make_handler()
+
+    await handler.handle_message(
+        message="/cancel",
+        conversation_id="conv-test",
+        channel="webui",
+    )
+
+    calls = handler.conversation_service.add_message.call_args_list
+    roles = [c.kwargs.get("role") or c.args[1] for c in calls]
+    assert "user" in roles
+    assert "assistant" in roles
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_cancels_running_subtasks():
+    """/cancel invokes cancel_all_for_conversation on the dispatcher."""
+    handler = _make_handler()
+    handler.async_task_dispatcher.cancel_all_for_conversation = MagicMock(return_value=["abc123"])
+
+    result = await handler.handle_message(
+        message="/cancel",
+        conversation_id="conv-test",
+        channel="webui",
+    )
+
+    handler.async_task_dispatcher.cancel_all_for_conversation.assert_called_once_with("conv-test")
+    assert "abc123" in result["cancelled_tasks"]
+    assert "1 background task" in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_no_subtasks_still_works():
+    """/cancel works cleanly when no sub-tasks are running."""
+    handler = _make_handler()
+    handler.async_task_dispatcher.cancel_all_for_conversation = MagicMock(return_value=[])
+
+    result = await handler.handle_message(
+        message="/cancel",
+        conversation_id="conv-test",
+        channel="webui",
+    )
+
+    assert result["cancelled"] is True
+    assert result["cancelled_tasks"] == []
+    # Response should not mention a task count when there were none
+    assert "background task" not in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_clears_suspended_state():
+    """/cancel calls _clear_suspended_state on the conversation."""
+    handler = _make_handler()
+    handler._clear_suspended_state = MagicMock(return_value=True)
+
+    await handler.handle_message(
+        message="/cancel",
+        conversation_id="conv-test",
+        channel="webui",
+    )
+
+    handler._clear_suspended_state.assert_called_once_with("conv-test")
+
+
+# ---------------------------------------------------------------------------
+# MessageHandler._clear_suspended_state
+# ---------------------------------------------------------------------------
+
+
+def test_clear_suspended_state_marks_message_cancelled():
+    """_clear_suspended_state updates the suspended message's metadata."""
+    handler = _make_handler()
+
+    suspended_msg = {
+        "message_id": "msg-suspended",
+        "role": "assistant",
+        "content": "What would you like?",
+        "metadata": json.dumps({"suspended_state": {"messages": [], "iteration": 1}}),
+    }
+    handler.conversation_service.message_repo.get_recent_messages.return_value = [suspended_msg]
+
+    cleared = handler._clear_suspended_state("conv-test")
+
+    assert cleared is True
+    handler.conversation_service.message_repo.update_metadata.assert_called_once_with(
+        "msg-suspended", {"cancelled": True}
+    )
+
+
+def test_clear_suspended_state_returns_false_when_nothing_suspended():
+    """_clear_suspended_state returns False when no suspended state is found."""
+    handler = _make_handler()
+    handler.conversation_service.message_repo.get_recent_messages.return_value = [
+        {"message_id": "m1", "role": "assistant", "content": "Hello", "metadata": None}
+    ]
+
+    cleared = handler._clear_suspended_state("conv-test")
+
+    assert cleared is False
+    handler.conversation_service.message_repo.update_metadata.assert_not_called()
+
+
+def test_clear_suspended_state_returns_false_on_empty_history():
+    """_clear_suspended_state returns False gracefully when history is empty."""
+    handler = _make_handler()
+    handler.conversation_service.message_repo.get_recent_messages.return_value = []
+
+    cleared = handler._clear_suspended_state("conv-test")
+
+    assert cleared is False


### PR DESCRIPTION
## Summary
This PR implements a `/cancel` slash command that allows users to stop all running background tasks for a conversation and clear any suspended ask_user state, enabling them to start fresh without leaving the conversation.

## Key Changes

- **AsyncTaskDispatcher.cancel_all_for_conversation()**: New method that cancels all running sub-tasks for a given conversation by:
  - Cancelling the underlying asyncio tasks
  - Marking AsyncTask records as "cancelled" with appropriate error messages
  - Persisting the final state
  - Returning a list of cancelled task IDs

- **MessageHandler /cancel command handler**: New command branch (Step 1b) that:
  - Calls `cancel_all_for_conversation()` to stop all running sub-tasks
  - Clears any suspended ask_user state via `_clear_suspended_state()`
  - Records both user and assistant messages in the conversation
  - Returns a clean response with cancellation details and a `cancelled=True` flag
  - Logs the cancellation action

- **MessageHandler._clear_suspended_state()**: New helper method that:
  - Searches recent conversation history for suspended ask_user state
  - Updates the suspended message's metadata to mark it as cancelled
  - Prevents subsequent messages from being treated as resumed executions
  - Returns True if a suspended state was found and cleared, False otherwise

## Implementation Details

- The `/cancel` command is checked early in message handling (Step 1b), before suspended state resumption (Step 1d)
- Cancelled tasks are marked with status "cancelled" and error message "Cancelled by /cancel command."
- The response includes a count of cancelled background tasks and their IDs when applicable
- Suspended state clearing uses JSON parsing to handle both string and dict metadata formats
- All operations include appropriate logging for debugging and monitoring
- Comprehensive test coverage includes edge cases (no tasks, other conversations, already-finished tasks)