### PR TITLE
Add skip guards to recipe jobs for idle-day optimization

### DIFF
--- a/src/core/migrations/060_recipe_skip_guards.sql
+++ b/src/core/migrations/060_recipe_skip_guards.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- Migration: 060_recipe_skip_guards
+-- Description: Make the two default nightly jobs skip their expensive LLM steps
+--              on days with no genuine user activity.
+--
+--              cron-system-memory (Nightly Memory Update) and cron-system-soul
+--              (Nightly Soul Update) fire every night regardless of whether the
+--              user talked to the assistant. Each runs several full LLM
+--              conversations per night (memory: 3, soul: 2), so quiet days cost
+--              real money for no benefit.
+--
+--              This patches their recipe `steps` JSON (defined in 048_recipes)
+--              with the generic skip-guard fields added to the recipe engine:
+--                - Step 1 (system_get_conversation_text): request a true rolling
+--                  24h window, and skip the rest of the recipe when it returns no
+--                  messages (skip_remaining_if_empty). Step 1 is a free SQL fetch,
+--                  so a fully idle night now costs zero LLM calls.
+--                - Step 3 (the extraction LLM step): skip the remaining
+--                  update/index steps when the model emits its "nothing to do"
+--                  sentinel (NO_NEW_FACTS / NO_STYLE_UPDATES), which the prompts
+--                  already produce but nothing previously acted on.
+--
+--              Uses surgical json_set on specific array indices so any other
+--              step content is preserved, and is scoped by job_id.
+-- Created: 2026-08-14
+-- ============================================================================
+
+-- Nightly Memory Update: step index 0 = fetch, step index 2 = extract facts.
+UPDATE cron_jobs
+SET steps = json_set(
+        json_set(
+            json_set(steps, '$[0].tool_parameters', json_object('hours', 24)),
+            '$[0].skip_remaining_if_empty', json('true')
+        ),
+        '$[2].skip_remaining_if_output_contains', 'NO_NEW_FACTS'
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE job_id = 'cron-system-memory' AND steps IS NOT NULL;
+
+-- Nightly Soul Update: step index 0 = fetch, step index 2 = extract style.
+UPDATE cron_jobs
+SET steps = json_set(
+        json_set(
+            json_set(steps, '$[0].tool_parameters', json_object('hours', 24)),
+            '$[0].skip_remaining_if_empty', json('true')
+        ),
+        '$[2].skip_remaining_if_output_contains', 'NO_STYLE_UPDATES'
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE job_id = 'cron-system-soul' AND steps IS NOT NULL;
+
+INSERT OR IGNORE INTO schema_migrations (version) VALUES ('060_recipe_skip_guards');

--- a/src/models/cron_jobs.py
+++ b/src/models/cron_jobs.py
@@ -29,6 +29,22 @@ class RecipeStep(BaseModel):
     uses_variable: Optional[str] = Field(
         None, description="Variable name produced by a prior step to inject as context"
     )
+    skip_remaining_if_empty: Optional[bool] = Field(
+        None,
+        description=(
+            "If this step produces no data (e.g. an empty result set), skip all "
+            "remaining steps and record the run as 'skipped'. Use on a cheap "
+            "probe step to avoid spending LLM calls when there is nothing to do."
+        ),
+    )
+    skip_remaining_if_output_contains: Optional[str] = Field(
+        None,
+        description=(
+            "If this step's output text contains this sentinel (case-insensitive), "
+            "skip all remaining steps and record the run as 'skipped'. Lets an LLM "
+            "step signal 'nothing to do' (e.g. NO_NEW_FACTS) and short-circuit."
+        ),
+    )
 
 
 # --- LLM Tool Parameter Models ---

--- a/src/models/monitoring.py
+++ b/src/models/monitoring.py
@@ -38,6 +38,14 @@ class GetConversationTextRequest(BaseModel):
         le=1000,
         description="Maximum number of messages to return (default 200, max 1000).",
     )
+    hours: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "If set, return messages from a rolling window of the last N hours "
+            "ending now, overriding 'since'. Use for a true 'last 24 hours'."
+        ),
+    )
 
 
 class GetPromptRequest(BaseModel):

--- a/src/services/cron_job.py
+++ b/src/services/cron_job.py
@@ -18,6 +18,60 @@ from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Keys under which tools commonly report a count of items produced. A value of 0
+# on any of these marks the output as empty for skip-guard purposes.
+_EMPTY_COUNT_KEYS = ("total_messages", "count", "total", "num_results")
+# Keys under which tools commonly return a list of items. An empty list marks the
+# output as empty.
+_EMPTY_LIST_KEYS = ("messages", "items", "results", "rows", "data")
+
+
+def _recipe_output_is_empty(result: Any) -> bool:
+    """Return True when a recipe step produced no meaningful data.
+
+    Generic across tools: unwraps the ``{"success", "result": ...}`` envelope
+    returned by ``ToolExecutor.execute_tool`` and inspects the common count/list
+    conventions. Kept deliberately conservative — it only reports "empty" when a
+    recognised signal clearly says so, so an unfamiliar result never trips the
+    guard by accident.
+    """
+    if not isinstance(result, dict):
+        return not result  # empty string / list / None
+
+    # Unwrap the pinned-tool envelope one level.
+    payload = result.get("result", result)
+    if not isinstance(payload, dict):
+        return not payload
+
+    for key in _EMPTY_COUNT_KEYS:
+        if key in payload:
+            try:
+                return int(payload[key]) == 0
+            except (TypeError, ValueError):
+                pass
+    for key in _EMPTY_LIST_KEYS:
+        if key in payload and isinstance(payload[key], (list, tuple, str)):
+            return len(payload[key]) == 0
+    return False
+
+
+def _recipe_output_text(result: Any) -> str:
+    """Best-effort extraction of a step's textual output for sentinel matching."""
+    if isinstance(result, dict):
+        # Prompt steps return {"response": ...}; fall back to the whole dict.
+        return str(result.get("response") or result)
+    return str(result)
+
+
+def _evaluate_skip_guards(step: Dict[str, Any], result: Any) -> Optional[str]:
+    """Return a human-readable reason if a step's skip guard trips, else None."""
+    if step.get("skip_remaining_if_empty") and _recipe_output_is_empty(result):
+        return "no_data"
+    sentinel = step.get("skip_remaining_if_output_contains")
+    if sentinel and sentinel.lower() in _recipe_output_text(result).lower():
+        return f"sentinel:{sentinel}"
+    return None
+
 
 class CronJobService:
     """Service for managing recurring scheduled tasks with APScheduler."""
@@ -263,10 +317,16 @@ class CronJobService:
                     self._run_job(job, execution_id, job_logger), timeout=self.max_job_timeout
                 )
 
-                self.repo.complete_execution(
-                    execution_id=execution_id, status="success", result=result
+                # A recipe that short-circuited via a skip guard is recorded as
+                # "skipped" (not "success") so idle runs are queryable and don't
+                # read as real work in the execution history.
+                status = (
+                    "skipped" if isinstance(result, dict) and result.get("skipped") else "success"
                 )
-                job_logger.info("Job completed successfully")
+                self.repo.complete_execution(
+                    execution_id=execution_id, status=status, result=result
+                )
+                job_logger.info("Job completed (%s)", status)
 
         except asyncio.TimeoutError:
             error_msg = f"Job exceeded timeout of {self.max_job_timeout}s"
@@ -389,6 +449,24 @@ class CronJobService:
                     )
 
                 results.append({"step": order, "status": "success", "result": result})
+
+                # --- Skip guards: short-circuit the rest of the recipe when a
+                # step signals there is nothing left to do. These only ever stop
+                # early — a genuine error takes the except branch below instead.
+                skip_reason = _evaluate_skip_guards(step, result)
+                if skip_reason:
+                    job_logger.info(
+                        "Step %s tripped skip guard (%s); skipping remaining steps",
+                        order,
+                        skip_reason,
+                    )
+                    results.append({"step": order, "status": "skipped_remaining"})
+                    return {
+                        "skipped": True,
+                        "skip_reason": skip_reason,
+                        "steps_executed": len(results),
+                        "results": results,
+                    }
 
             except Exception as exc:
                 job_logger.error("Step %s failed: %s", order, exc)

--- a/src/services/system.py
+++ b/src/services/system.py
@@ -548,6 +548,7 @@ class SystemService:
         until: Optional[str] = None,
         channel: Optional[str] = None,
         limit: int = 200,
+        hours: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Return conversation message text within a time window.
 
@@ -556,15 +557,26 @@ class SystemService:
             until: ISO-8601 end timestamp (inclusive). Defaults to now.
             channel: Optional channel filter (e.g. 'webui', 'whatsapp').
             limit: Max number of messages to return (default 200, max 1000).
+            hours: If set, use a rolling window of the last ``hours`` hours ending
+                now, overriding ``since`` (and ``until`` when ``until`` is unset).
+                This is what the nightly jobs use for a true "last 24 hours".
 
         Returns:
             Dict with messages list, metadata, and success flag.
+
+        Notes:
+            Internal/transparency rows (``is_internal = 1``) are always excluded.
+            When no explicit ``channel`` is given, the ``system`` channel is also
+            excluded so the nightly jobs' own scheduled runs are not mistaken for
+            user activity (which would defeat the "skip when idle" guard).
         """
         if not self._db_manager:
             return {"success": False, "error": "Database not available", "messages": []}
 
         try:
-            if not since:
+            if hours is not None:
+                since = (datetime.utcnow() - timedelta(hours=hours)).isoformat()
+            elif not since:
                 since = (
                     datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
                 )
@@ -591,6 +603,7 @@ class SystemService:
                     WHERE m.timestamp >= ?
                       AND m.timestamp <= ?
                       AND m.role IN ('user', 'assistant')
+                      AND m.is_internal = 0
                       AND c.channel = ?
                     ORDER BY m.timestamp ASC
                     LIMIT ?
@@ -610,6 +623,8 @@ class SystemService:
                     WHERE m.timestamp >= ?
                       AND m.timestamp <= ?
                       AND m.role IN ('user', 'assistant')
+                      AND m.is_internal = 0
+                      AND c.channel != 'system'
                     ORDER BY m.timestamp ASC
                     LIMIT ?
                     """,

--- a/src/ui/static/monitoring.html
+++ b/src/ui/static/monitoring.html
@@ -174,6 +174,11 @@
             color: var(--success-color);
         }
 
+        .status-badge-skipped {
+            background: rgba(107, 114, 128, 0.1);
+            color: var(--text-muted);
+        }
+
         /* Job Actions */
         .job-actions {
             display: flex;
@@ -1616,6 +1621,7 @@
                             const statusBadge = exec.status === 'success' ? 'success'
                                 : exec.status === 'failed' ? 'failed'
                                 : exec.status === 'cancelled' ? 'cancelled'
+                                : exec.status === 'skipped' ? 'skipped'
                                 : 'running';
                             const statusText = exec.status.charAt(0).toUpperCase() + exec.status.slice(1);
 
@@ -1771,6 +1777,8 @@
                 if (s.prompt_template) step.prompt_template = s.prompt_template;
                 if (s.stores_as) step.stores_as = s.stores_as;
                 if (s.uses_variable) step.uses_variable = s.uses_variable;
+                if (s.skip_remaining_if_empty) step.skip_remaining_if_empty = s.skip_remaining_if_empty;
+                if (s.skip_remaining_if_output_contains) step.skip_remaining_if_output_contains = s.skip_remaining_if_output_contains;
                 return step;
             });
 

--- a/tests/test_cron_jobs.py
+++ b/tests/test_cron_jobs.py
@@ -628,3 +628,153 @@ class TestCronJobModels:
         response = CronJobListResponse(jobs=jobs, total=3)
         assert response.total == 3
         assert len(response.jobs) == 3
+
+
+class TestRecipeSkipGuards:
+    """Tests for recipe step skip-guards (skip when there's nothing to do)."""
+
+    def test_output_is_empty_helpers(self):
+        from src.services.cron_job import _recipe_output_is_empty
+
+        # Pinned-tool envelope wrapping get_conversation_text's empty result.
+        assert _recipe_output_is_empty(
+            {"success": True, "result": {"total_messages": 0, "messages": []}}
+        )
+        assert _recipe_output_is_empty({"total_messages": 0, "messages": []})
+        assert _recipe_output_is_empty({"items": []})
+        assert _recipe_output_is_empty("")
+        assert _recipe_output_is_empty([])
+        # Non-empty / unrecognised results must NOT trip the guard.
+        assert not _recipe_output_is_empty(
+            {"success": True, "result": {"total_messages": 2, "messages": [1, 2]}}
+        )
+        assert not _recipe_output_is_empty({"status": "success", "response": "text"})
+
+    def test_evaluate_skip_guards(self):
+        from src.services.cron_job import _evaluate_skip_guards
+
+        empty_step = {"skip_remaining_if_empty": True}
+        assert _evaluate_skip_guards(empty_step, {"total_messages": 0}) == "no_data"
+        assert _evaluate_skip_guards(empty_step, {"total_messages": 5}) is None
+
+        sentinel_step = {"skip_remaining_if_output_contains": "NO_NEW_FACTS"}
+        assert (
+            _evaluate_skip_guards(sentinel_step, {"response": "  no_new_facts  "})
+            == "sentinel:NO_NEW_FACTS"
+        )
+        assert _evaluate_skip_guards(sentinel_step, {"response": "found a fact"}) is None
+
+    @pytest.mark.asyncio
+    async def test_recipe_skips_remaining_when_step_empty(self, clean_temp_db):
+        """An empty probe step short-circuits the recipe with no LLM calls."""
+        repo = CronJobRepository(clean_temp_db)
+        tool_executor = MagicMock()
+        tool_executor.execute_tool = AsyncMock(
+            return_value={"success": True, "result": {"total_messages": 0, "messages": []}}
+        )
+        message_handler = MagicMock()
+        message_handler.handle_message = AsyncMock()  # must never be awaited
+        service = CronJobService(repo, tool_executor=tool_executor, message_handler=message_handler)
+
+        job = {
+            "job_id": "cron-skip-empty",
+            "name": "Skip Empty",
+            "steps": [
+                {
+                    "order": 1,
+                    "description": "fetch",
+                    "tool_name": "system_get_conversation_text",
+                    "stores_as": "conversations",
+                    "skip_remaining_if_empty": True,
+                },
+                {
+                    "order": 2,
+                    "description": "extract",
+                    "prompt_template": "analyse",
+                    "uses_variable": "conversations",
+                },
+            ],
+        }
+
+        job_logger = MagicMock()
+        result = await service._run_recipe_job(job, job_logger)
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "no_data"
+        tool_executor.execute_tool.assert_awaited_once()
+        message_handler.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_recipe_skips_remaining_on_sentinel(self, clean_temp_db):
+        """A 'nothing to do' sentinel from a prompt step skips later steps."""
+        repo = CronJobRepository(clean_temp_db)
+        tool_executor = MagicMock()
+        tool_executor.execute_tool = AsyncMock(
+            return_value={"success": True, "result": {"total_messages": 3, "messages": [1, 2, 3]}}
+        )
+        service = CronJobService(repo, tool_executor=tool_executor, message_handler=MagicMock())
+        # Stub the LLM step to return the sentinel; a later tool step must not run.
+        service._run_message_handler_job = AsyncMock(
+            return_value={"status": "success", "response": "NO_NEW_FACTS"}
+        )
+
+        job = {
+            "job_id": "cron-skip-sentinel",
+            "name": "Skip Sentinel",
+            "steps": [
+                {
+                    "order": 1,
+                    "description": "fetch",
+                    "tool_name": "system_get_conversation_text",
+                    "stores_as": "conversations",
+                    "skip_remaining_if_empty": True,
+                },
+                {
+                    "order": 2,
+                    "description": "extract",
+                    "prompt_template": "analyse",
+                    "uses_variable": "conversations",
+                    "stores_as": "facts",
+                    "skip_remaining_if_output_contains": "NO_NEW_FACTS",
+                },
+                {
+                    "order": 3,
+                    "description": "update prompt",
+                    "tool_name": "system_update_memory_prompt",
+                    "uses_variable": "facts",
+                },
+            ],
+        }
+
+        result = await service._run_recipe_job(job, MagicMock())
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "sentinel:NO_NEW_FACTS"
+        # Step 1 (fetch) executed; step 3 (update) never did.
+        assert service._run_message_handler_job.await_count == 1
+
+    def test_seeded_nightly_jobs_have_skip_guards(self, clean_temp_db):
+        """Migration 060 patches both nightly jobs with skip guards."""
+        repo = CronJobRepository(clean_temp_db)
+        for job_id, sentinel in (
+            ("cron-system-memory", "NO_NEW_FACTS"),
+            ("cron-system-soul", "NO_STYLE_UPDATES"),
+        ):
+            job = repo.get_job(job_id)
+            steps = job["steps"]
+            assert steps[0]["tool_parameters"] == {"hours": 24}
+            assert steps[0]["skip_remaining_if_empty"] is True
+            assert steps[2]["skip_remaining_if_output_contains"] == sentinel
+
+    def test_recipe_step_model_accepts_guard_fields(self):
+        from src.models.cron_jobs import RecipeStep
+
+        step = RecipeStep(
+            order=1,
+            description="probe",
+            tool_name="system_get_conversation_text",
+            skip_remaining_if_empty=True,
+            skip_remaining_if_output_contains="NO_NEW_FACTS",
+        )
+        assert step.skip_remaining_if_empty is True
+        assert step.skip_remaining_if_output_contains == "NO_NEW_FACTS"

--- a/tests/test_system_conversation_text.py
+++ b/tests/test_system_conversation_text.py
@@ -1,0 +1,71 @@
+"""Tests for SystemService.get_conversation_text activity filtering.
+
+These cover the fixes that make the nightly memory/soul jobs' "is there any
+activity?" probe accurate:
+- internal/transparency rows (is_internal=1) are excluded
+- the 'system' channel (the jobs' own scheduled runs) is excluded when no
+  explicit channel is requested
+- the `hours` parameter yields a true rolling window
+"""
+
+from src.core.repositories.conversation import ConversationRepository
+from src.core.repositories.message import MessageRepository
+from src.services.system import SystemService
+
+
+def _seed(db):
+    conv_repo = ConversationRepository(db)
+    msg_repo = MessageRepository(db)
+
+    # A real user conversation on the webui channel.
+    conv_repo.create(conversation_id="c-user", channel="webui", contact_identifier="u1")
+    msg_repo.create("c-user", "user", "hello there")
+    msg_repo.create("c-user", "assistant", "hi, how can I help?")
+    # A transparency/internal row inside the same conversation — must be ignored.
+    msg_repo.create("c-user", "assistant", "SYSTEM PROMPT DUMP", is_internal=True)
+
+    # The nightly job's own scheduled run, on the 'system' channel — must be
+    # ignored so the job never counts itself as user activity.
+    conv_repo.create(conversation_id="c-sys", channel="system", contact_identifier="cron_x")
+    msg_repo.create("c-sys", "user", "nightly memory update prompt")
+    msg_repo.create("c-sys", "assistant", "extracted some facts")
+
+
+def test_excludes_internal_and_system_channel(clean_temp_db):
+    _seed(clean_temp_db)
+    svc = SystemService(db_manager=clean_temp_db)
+
+    res = svc.get_conversation_text(hours=24)
+
+    assert res["success"] is True
+    # Only the 2 real user/assistant rows from the webui conversation.
+    assert res["total_messages"] == 2
+    channels = {m["channel"] for m in res["messages"]}
+    assert channels == {"webui"}
+    contents = [m["content"] for m in res["messages"]]
+    assert "SYSTEM PROMPT DUMP" not in contents
+
+
+def test_empty_when_only_system_activity(clean_temp_db):
+    """A day where only the jobs themselves 'talked' reads as idle."""
+    conv_repo = ConversationRepository(clean_temp_db)
+    msg_repo = MessageRepository(clean_temp_db)
+    conv_repo.create(conversation_id="c-sys", channel="system", contact_identifier="cron_x")
+    msg_repo.create("c-sys", "assistant", "job chatter")
+
+    svc = SystemService(db_manager=clean_temp_db)
+    res = svc.get_conversation_text(hours=24)
+
+    assert res["success"] is True
+    assert res["total_messages"] == 0
+    assert res["messages"] == []
+
+
+def test_explicit_channel_still_filters_internal(clean_temp_db):
+    _seed(clean_temp_db)
+    svc = SystemService(db_manager=clean_temp_db)
+
+    res = svc.get_conversation_text(hours=24, channel="webui")
+
+    assert res["total_messages"] == 2
+    assert all(m["channel"] == "webui" for m in res["messages"])


### PR DESCRIPTION
## Summary
Implements skip guards for recipe-based cron jobs to short-circuit execution when there's no meaningful work to do. This prevents expensive LLM calls on idle days, particularly benefiting the nightly memory and soul update jobs.

## Key Changes

### Core Skip Guard Implementation
- Added `_recipe_output_is_empty()` helper to detect empty results across common tool output patterns (count keys: `total_messages`, `count`, `total`, `num_results`; list keys: `messages`, `items`, `results`, `rows`, `data`)
- Added `_evaluate_skip_guards()` to check both guard types and return a human-readable skip reason
- Added `_recipe_output_text()` for sentinel value extraction from step outputs
- Modified `_run_recipe_job()` to evaluate guards after each step and short-circuit remaining steps when triggered
- Updated execution status tracking to record skipped runs as `"skipped"` (not `"success"`) for queryability

### Data Model Updates
- Extended `RecipeStep` model with two new optional fields:
  - `skip_remaining_if_empty`: Skip remaining steps when a step produces no data
  - `skip_remaining_if_output_contains`: Skip remaining steps when output contains a sentinel value (case-insensitive)

### System Service Enhancement
- Enhanced `get_conversation_text()` with `hours` parameter for true rolling-window queries
- Added filtering to exclude `is_internal = 1` rows (transparency/system prompts)
- Added automatic exclusion of `system` channel when no explicit channel is specified (prevents jobs from counting their own scheduled runs as user activity)

### Database Migration
- Migration `060_recipe_skip_guards.sql` patches the two default nightly jobs:
  - `cron-system-memory`: Step 1 fetches last 24 hours with skip-on-empty; Step 3 skips on `NO_NEW_FACTS` sentinel
  - `cron-system-soul`: Step 1 fetches last 24 hours with skip-on-empty; Step 3 skips on `NO_STYLE_UPDATES` sentinel

### UI Updates
- Added `.status-badge-skipped` styling for skipped execution status
- Updated execution status badge logic to display skipped runs with muted styling

## Implementation Details
- Skip guards are evaluated conservatively—only recognized patterns trigger the guard to prevent accidental short-circuits
- The `system` channel exclusion in `get_conversation_text()` is only applied when no explicit channel is requested, preserving explicit channel queries
- Skipped runs return a structured result with `skipped: true`, `skip_reason`, `steps_executed`, and `results` for audit trails
- Job logger records skip events with the triggering reason for debugging

## Testing
- Comprehensive test coverage for helper functions and skip guard evaluation
- Integration tests verify recipe short-circuiting behavior with mocked tools and LLM steps
- Tests confirm seeded nightly jobs have skip guards properly applied
- Tests for `get_conversation_text()` filtering (internal rows, system channel, rolling window)