### PR TITLE
Add Anthropic provider support with OpenAI SDK compatibility

### DIFF
--- a/docs/integrations/llm-providers.md
+++ b/docs/integrations/llm-providers.md
@@ -4,6 +4,7 @@ This guide explains how to obtain API credentials for different LLM providers.
 
 ## Table of Contents
 - [OpenRouter (Recommended)](#openrouter-recommended)
+- [Anthropic](#anthropic)
 - [Groq](#groq)
 - [Local LLM (Ollama)](#local-llm-ollama)
 - [Self-Hosted Inference (vLLM)](#self-hosted-inference-vllm)
@@ -52,6 +53,65 @@ Pay-as-you-go pricing varies by model. Check current pricing at [https://openrou
 - No vendor lock-in
 - Automatic failover
 - Usage tracking
+
+---
+
+## Anthropic
+
+Connect directly to Claude models using your own Anthropic API key, instead of
+routing through OpenRouter. Open Assistant talks to Anthropic through its
+official [OpenAI SDK compatibility layer](https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk),
+so it uses the same request path as every other provider here — no separate
+integration to maintain.
+
+### Setup Steps
+
+1. **Sign up**: Visit [https://console.anthropic.com/](https://console.anthropic.com/)
+2. **Get API Key**:
+   - Log in to your account
+   - Go to [Settings > API Keys](https://platform.claude.com/settings/keys)
+   - Click "Create Key"
+   - Copy your API key (starts with `sk-ant-`)
+3. **Configure in Settings**:
+   - Provider: `anthropic`
+   - API Key: Your Anthropic API key
+   - Model: `claude-sonnet-5` (or another Claude model — see below)
+   - Base URL: `https://api.anthropic.com/v1/` (pre-filled automatically)
+
+### Available Models
+
+- `claude-opus-5` - most capable, best for complex reasoning and agentic tasks
+- `claude-sonnet-5` - strong balance of intelligence, speed, and cost
+- `claude-haiku-4-5` - fastest and cheapest, good for simple/high-volume tasks
+
+Browse current models and pricing at
+[https://platform.claude.com/docs/en/about-claude/models](https://platform.claude.com/docs/en/about-claude/models).
+
+### Pricing
+
+Pay-as-you-go, billed directly by Anthropic. See
+[https://platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing).
+
+### Notes
+
+- **Use plain Claude model names**, not the `anthropic/...` OpenRouter-style
+  identifiers (e.g. `claude-sonnet-5`, not `anthropic/claude-sonnet-4.6`).
+- Requests go through Anthropic's OpenAI-compatible endpoint, which covers
+  everything Open Assistant needs (chat, tool calls, streaming, usage
+  reporting). A few OpenAI-only knobs are silently ignored — see Anthropic's
+  [compatibility limitations](https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk#important-openai-compatibility-limitations)
+  if you're curious what doesn't carry over (e.g. prompt caching and strict
+  JSON-schema enforcement aren't available through this path).
+- If you previously tried to point the `custom` provider at
+  `https://api.anthropic.com` and got errors, that's expected — Anthropic's
+  native `/v1/messages` endpoint uses a different request/response shape than
+  OpenAI's `/v1/chat/completions`. Selecting the `anthropic` provider (or
+  using the `/v1/` compatibility base URL above) fixes this.
+
+**Benefits**:
+- Direct relationship with Anthropic — no intermediary
+- No markup — pay Anthropic's rates directly
+- Access to the newest Claude models as soon as Anthropic ships them
 
 ---
 
@@ -270,6 +330,11 @@ port) and point a `custom` provider at it.
 - You want to try different providers easily
 - You want automatic failover
 
+### Use Anthropic if:
+- You specifically want Claude models with no intermediary
+- You already have an Anthropic API key / billing relationship
+- You want the newest Claude models without waiting on a router to add them
+
 ### Use Groq if:
 - You need ultra-low latency responses
 - You want fast inference at low cost
@@ -330,6 +395,7 @@ Common issues:
 ## Need Help?
 
 - **OpenRouter**: [Documentation](https://openrouter.ai/docs)
+- **Anthropic**: [Documentation](https://platform.claude.com/docs)
 - **Groq**: [Documentation](https://console.groq.com/docs)
 - **Ollama**: [Documentation](https://ollama.ai/docs)
 - **vLLM**: [Documentation](https://docs.vllm.ai/)

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -185,7 +185,8 @@ Settings are organized into the following categories:
 - **Description**: Language model provider and settings
 - **Max Context Tokens** (`memory.max_tokens`, ENV `MEMORY_MAX_TOKENS`, default `100000`): tokens of conversation history loaded each turn — distinct from `llm.max_tokens`, which caps the response. The default is sized for 200K-context models, leaving headroom for the system prompt, tool definitions, in-turn tool results, and the response. Lower it for smaller-window models.
 - **Max Tool Output Chars** (`llm.tool_output_max_chars`, ENV `TOOL_RESULT_OFFLOAD_THRESHOLD`, default `300000` ≈ 75K tokens): tool results larger than this are written to a temp file and replaced in-context with a compact pointer (schema + sample) for `python_agent` to process, so a single large result never overflows the context window. Raise it to keep more inline; lower it to offload sooner.
-- **Supported Providers**: `openrouter`, `groq`, `ollama`, `vllm`, `custom`
+- **Supported Providers**: `openrouter`, `anthropic`, `groq`, `ollama`, `vllm`, `custom`
+- **Anthropic**: direct Claude API access (default base URL `https://api.anthropic.com/v1/`), via Anthropic's OpenAI SDK compatibility layer. Requires an Anthropic API key and plain Claude model names (e.g. `claude-sonnet-5`, not `anthropic/claude-sonnet-4.6`). See [LLM Providers](../integrations/llm-providers.md#anthropic).
 - **Local providers**: `ollama` (default base URL `http://localhost:11434/v1`) and `vllm` (default `http://localhost:8000/v1`) need no API key. For both, the media/worker/writer models always fall back to the main model since each endpoint serves a single model.
 
 ### 6. Google Integration (Gmail, Calendar)
@@ -302,7 +303,7 @@ config/
   - Set `whatsapp.enabled=true`
 
 ### LLM Configuration
-- [ ] Choose LLM provider: `llm.provider` (openrouter, groq, ollama, vllm, custom)
+- [ ] Choose LLM provider: `llm.provider` (openrouter, anthropic, groq, ollama, vllm, custom)
 - [ ] Set model: `llm.model` (e.g., `anthropic/claude-sonnet-4.6`)
 - [ ] Configure API key for chosen provider (stored encrypted; not needed for `ollama`/`vllm`)
 - [ ] Optional: Set `llm.base_url` (auto-filled per provider; required for `custom`)

--- a/docs/setup/install-and-update.md
+++ b/docs/setup/install-and-update.md
@@ -21,7 +21,7 @@ Verifies Docker is present and reachable. On Linux, if Docker is missing and the
 Asks two things:
 
 - **Application URL** — where the assistant will be reachable (defaults to your local IP and port). Used for OAuth redirects and CORS.
-- **LLM provider** — OpenRouter, Groq, or a custom OpenAI-compatible endpoint. After choosing a provider, you pick a model and enter your API key (input is hidden).
+- **LLM provider** — OpenRouter, Anthropic, Groq, or a custom OpenAI-compatible endpoint. After choosing a provider, you pick a model and enter your API key (input is hidden).
 
 No configuration files to edit by hand.
 

--- a/install.sh
+++ b/install.sh
@@ -240,7 +240,7 @@ collect_llm_config() {
   echo ""
   echo -e "  ${BOLD}LLM Provider${RESET}"
   prompt_choice CFG_LLM_PROVIDER "Which provider?" \
-    "openrouter,groq,custom" "openrouter"
+    "openrouter,anthropic,groq,custom" "openrouter"
 
   case "$CFG_LLM_PROVIDER" in
     openrouter)
@@ -248,6 +248,12 @@ collect_llm_config() {
       prompt_choice CFG_LLM_MODEL "Model" \
         "anthropic/claude-sonnet-4.6,anthropic/claude-3.5-sonnet,z-ai/glm-5-turbo,openai/gpt-4o,openai/gpt-4o-mini,google/gemini-2.0-flash-001,meta-llama/llama-3.3-70b-instruct" \
         "anthropic/claude-sonnet-4.6"
+      ;;
+    anthropic)
+      CFG_LLM_BASE_URL="https://api.anthropic.com/v1/"
+      prompt_choice CFG_LLM_MODEL "Model" \
+        "claude-sonnet-5,claude-opus-5,claude-haiku-4-5" \
+        "claude-sonnet-5"
       ;;
     groq)
       CFG_LLM_BASE_URL="https://api.groq.com/openai/v1"

--- a/src/core/llm_client.py
+++ b/src/core/llm_client.py
@@ -1,4 +1,4 @@
-"""LLM client for API calls through OpenRouter or other providers."""
+"""LLM client for API calls through OpenRouter, Anthropic, or other providers."""
 
 import logging
 from typing import Any
@@ -22,6 +22,7 @@ class LLMPausedError(Exception):
 # Default base URLs for each provider
 PROVIDER_BASE_URLS = {
     "openrouter": "https://openrouter.ai/api/v1",
+    "anthropic": "https://api.anthropic.com/v1/",
     "groq": "https://api.groq.com/openai/v1",
     "ollama": "http://localhost:11434/v1",
     "vllm": "http://localhost:8000/v1",
@@ -50,7 +51,8 @@ class LLMConfig(BaseModel):
     """Configuration for LLM client."""
 
     provider: str = Field(
-        default="openrouter", description="LLM provider (openrouter, groq, ollama, vllm, custom)"
+        default="openrouter",
+        description="LLM provider (openrouter, anthropic, groq, ollama, vllm, custom)",
     )
     model: str = Field(default="anthropic/claude-3.5-sonnet", description="Model identifier")
     api_key: str = Field(
@@ -140,7 +142,10 @@ class LLMClient:
     """
     Client for making LLM API calls.
 
-    Supports OpenRouter, Groq, and other OpenAI-compatible APIs.
+    Supports OpenRouter, Anthropic, Groq, and other OpenAI-compatible APIs.
+    Anthropic is reached via its official OpenAI SDK compatibility layer
+    (https://api.anthropic.com/v1/) rather than the native Anthropic SDK, so
+    it goes through the same OpenAI client path as every other provider here.
     """
 
     def __init__(self, config: LLMConfig):

--- a/src/core/usage_recorder.py
+++ b/src/core/usage_recorder.py
@@ -19,9 +19,9 @@ Design notes
   try/except and logged. Delegates to :class:`LlmConsumptionRepository`, which
   uses :class:`BaseRepository` connection handling.
 * **Provider scope.** Works for any OpenAI-compatible provider that returns
-  ``usage`` on non-streaming completions (OpenRouter, OpenAI, Groq; Ollama/vLLM
-  usually). When ``usage`` is absent the recorder stores zeros and flags
-  ``missing_usage`` so the gap is visible rather than silent.
+  ``usage`` on non-streaming completions (OpenRouter, OpenAI, Anthropic, Groq;
+  Ollama/vLLM usually). When ``usage`` is absent the recorder stores zeros and
+  flags ``missing_usage`` so the gap is visible rather than silent.
 """
 
 from typing import Any, Dict, Optional

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -272,11 +272,11 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
     "llm.provider": SettingDefinition(
         key="llm.provider",
         display_name="LLM Provider",
-        description="LLM provider to use (openrouter, groq, ollama, vllm, or custom)",
+        description="LLM provider to use (openrouter, anthropic, groq, ollama, vllm, or custom)",
         value_type=SettingValueType.STRING,
         category=ConfigCategory.LLM,
         default_value="openrouter",
-        options=["openrouter", "groq", "ollama", "vllm", "custom"],
+        options=["openrouter", "anthropic", "groq", "ollama", "vllm", "custom"],
         env_var_name="LLM_PROVIDER",
         display_order=1,
         ui_widget="select",
@@ -288,6 +288,9 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
             "API key for the LLM provider. Not required for local servers like "
             "Ollama or vLLM (leave blank unless vLLM was started with --api-key)."
         ),
+        # NOTE: for Anthropic, this is your Claude API key from
+        # https://platform.claude.com/settings/keys — Open Assistant talks to
+        # it over Anthropic's OpenAI SDK compatibility endpoint.
         value_type=SettingValueType.STRING,
         category=ConfigCategory.LLM,
         is_sensitive=True,
@@ -314,6 +317,7 @@ SETTING_DEFINITIONS: Dict[str, SettingDefinition] = {
         display_name="Base URL",
         description=(
             "API endpoint URL for the LLM provider. "
+            "Anthropic default: https://api.anthropic.com/v1/ — "
             "Ollama default: http://localhost:11434/v1 — "
             "vLLM default: http://localhost:8000/v1"
         ),

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -59,6 +59,35 @@ class TestLLMClient:
                 "X-Title": "Open Assistant",
             }
 
+    def test_anthropic_initialization(self):
+        """Test initialization for the Anthropic provider.
+
+        Anthropic is reached through its OpenAI SDK compatibility layer, so it
+        goes through the same OpenAI client as OpenRouter/custom — just with a
+        different base URL and no extra headers.
+        """
+        config = LLMConfig(
+            provider="anthropic",
+            model="claude-sonnet-5",
+            api_key="test-key",
+            base_url="https://api.anthropic.com/v1/",
+        )
+
+        with patch("src.core.llm_client.OpenAI") as mock_openai:
+            LLMClient(config)
+
+            mock_openai.assert_called_once()
+            _, kwargs = mock_openai.call_args
+            assert kwargs["api_key"] == "test-key"
+            assert kwargs["base_url"] == "https://api.anthropic.com/v1/"
+            assert kwargs["default_headers"] is None
+
+    def test_anthropic_default_base_url(self):
+        """Test that get_default_base_url returns Anthropic's compat endpoint."""
+        from src.core.llm_client import get_default_base_url
+
+        assert get_default_base_url("anthropic") == "https://api.anthropic.com/v1/"
+
     def test_sanitize_messages(self):
         """Test message sanitization logic."""
         config = LLMConfig(


### PR DESCRIPTION
## Summary
Add native support for Anthropic's Claude models as a first-class LLM provider, leveraging Anthropic's official OpenAI SDK compatibility layer to avoid maintaining a separate integration.

## Key Changes

- **LLM Client**: Added `anthropic` to the list of supported providers with default base URL `https://api.anthropic.com/v1/`
  - Updated provider descriptions and docstrings to include Anthropic
  - Anthropic requests route through the same OpenAI client as other providers (no separate SDK needed)

- **Configuration**: 
  - Added `anthropic` as a provider option in `LLMConfig` and settings definitions
  - Updated all provider option lists across config files to include `anthropic`
  - Added helpful note in `config.py` clarifying that Anthropic API keys come from `https://platform.claude.com/settings/keys`

- **Installation & Setup**:
  - Updated `install.sh` to include `anthropic` in provider selection with model choices (`claude-sonnet-5`, `claude-opus-5`, `claude-haiku-4-5`)
  - Auto-sets base URL to Anthropic's compatibility endpoint during setup

- **Documentation**:
  - Added comprehensive Anthropic section to `llm-providers.md` with setup steps, available models, pricing, and important notes about model naming and compatibility limitations
  - Added Anthropic to provider comparison section with decision criteria
  - Updated all references to supported providers across docs

- **Tests**: Added test cases for Anthropic initialization and default base URL resolution

## Implementation Details

- Anthropic is accessed via its OpenAI-compatible `/v1/` endpoint rather than the native Anthropic SDK, allowing it to use the same request/response path as OpenRouter and other providers
- Plain Claude model names are used (e.g., `claude-sonnet-5`) rather than OpenRouter-style identifiers (e.g., `anthropic/claude-sonnet-4.6`)
- No additional headers are sent for Anthropic (unlike OpenRouter which includes `X-Title`)
- Documentation includes notes about OpenAI compatibility limitations (e.g., prompt caching not available through this path)