### PR TITLE
UI redesign: left sidebar nav, contrast fixes, reworked chat, consistent typography

### DIFF
--- a/src/ui/static/artifacts.html
+++ b/src/ui/static/artifacts.html
@@ -29,8 +29,6 @@
     <link rel="stylesheet" href="/static/css/common.css">
     <link rel="stylesheet" href="/static/css/mobile.css">
     <style>
-        .main-container { align-items: flex-start; }
-
         .artifacts-container {
             background: var(--card-background);
             border-radius: 16px;
@@ -246,6 +244,7 @@
 <body>
     <div id="navbar-root"></div>
 
+    <div class="page-content">
     <div class="main-container">
         <div class="artifacts-container">
             <div class="artifacts-header">
@@ -257,6 +256,7 @@
     </div>
 
     <div id="footer-root"></div>
+    </div>
 
     <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>

--- a/src/ui/static/artifacts.html
+++ b/src/ui/static/artifacts.html
@@ -254,8 +254,6 @@
             <div id="artifacts" class="table-scroll">Loading...</div>
         </div>
     </div>
-
-    <div id="footer-root"></div>
     </div>
 
     <script src="/static/js/components.js"></script>

--- a/src/ui/static/artifacts.html
+++ b/src/ui/static/artifacts.html
@@ -112,7 +112,7 @@
             font-size: 0.8rem;
             cursor: pointer;
             background: var(--primary-color);
-            color: #0a0a0a;
+            color: var(--color-on-primary);
             transition: opacity 0.2s;
         }
         .job-action-btn:hover { opacity: 0.8; }
@@ -244,26 +244,7 @@
     </style>
 </head>
 <body>
-    <nav class="navbar">
-        <div class="navbar-content">
-            <div class="navbar-brand">
-                <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
-                <span>Open Assistant</span>
-                <span class="navbar-brand-short">OA</span>
-            </div>
-            <div class="navbar-links">
-                <a href="/" class="nav-link">Chat</a>
-                <a href="/artifacts" class="nav-link">Artifacts</a>
-                <a href="/settings" class="nav-link">Settings</a>
-                <a href="/monitoring" class="nav-link">Monitoring</a>
-            </div>
-            <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
-        </div>
-    </nav>
+    <div id="navbar-root"></div>
 
     <div class="main-container">
         <div class="artifacts-container">
@@ -275,6 +256,9 @@
         </div>
     </div>
 
+    <div id="footer-root"></div>
+
+    <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>
     <script>
         const BASE = window.INSTANCE_BASE_PATH || '';

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -11,7 +11,10 @@
     --color-primary: #00ff00;
     --color-primary-dark: #00aa00;
     --color-primary-gradient: linear-gradient(135deg, #00ff00 0%, #00aa00 100%);
-    --color-primary-glow: rgba(0, 255, 0, 0.3);
+    /* Dimmed from the original 0.3 alpha — every hover/focus "glow" in the
+       app derives from this one token, so a sleeker, less neon feel is a
+       one-line change here rather than editing each box-shadow. */
+    --color-primary-glow: rgba(0, 255, 0, 0.14);
 
     /* Colors - Backgrounds */
     --color-bg: #0f0f0f;
@@ -67,11 +70,21 @@
     --warning-background: var(--color-warning-bg);
 }
 
+/* height:100% (not min-height:100vh) on both html and body gives every
+   descendant a real, definite height to flex/stretch against — so
+   "fill the rest of the screen" layouts (the chat page in particular)
+   can be built with plain flexbox stretching instead of calc(100vh - N)
+   arithmetic that silently drifts out of sync whenever spacing above
+   or below it changes. */
+html {
+    height: 100%;
+}
+
 body {
     font-family: 'Courier New', 'Consolas', 'Monaco', 'Menlo', 'Liberation Mono', monospace;
     background: var(--color-bg);
     color: var(--color-text);
-    min-height: 100vh;
+    height: 100%;
     display: flex;
     flex-direction: column;
 }
@@ -157,6 +170,16 @@ body {
     opacity: 1;
 }
 
+/* PWA "install" nav entry (js/pwa.js) — kept visually distinct (always
+   green-tinted, not just on hover/active) since it's a one-off action,
+   not a destination. Desktop hides it: installing "an app" to a home
+   screen is a mobile affordance, not a desktop one. */
+.pwa-install-btn {
+    background: rgba(0, 255, 0, 0.1);
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+}
+
 /* Icon sprite <use> references throughout the app */
 .icon {
     width: 1.1em;
@@ -172,6 +195,7 @@ body {
 .page-content {
     flex: 1;
     min-width: 0;
+    min-height: 0;
     display: flex;
     flex-direction: column;
 }
@@ -179,6 +203,7 @@ body {
 /* Main Content Container */
 .main-container {
     flex: 1;
+    min-height: 0;
     display: flex;
     justify-content: center;
     align-items: flex-start;
@@ -226,7 +251,7 @@ body {
 .btn-primary {
     background: rgba(0, 255, 0, 0.1);
     color: var(--color-primary);
-    border: 2px solid var(--color-primary);
+    border: 1px solid var(--color-primary);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -238,7 +263,7 @@ body {
 .btn-secondary {
     background: rgba(136, 136, 136, 0.1);
     color: var(--color-text);
-    border: 2px solid var(--color-text);
+    border: 1px solid var(--color-text);
 }
 
 .btn-secondary:hover:not(:disabled) {
@@ -250,23 +275,23 @@ body {
 .btn-danger {
     background: rgba(255, 0, 0, 0.1);
     color: var(--color-error);
-    border: 2px solid var(--color-error);
+    border: 1px solid var(--color-error);
 }
 
 .btn-danger:hover:not(:disabled) {
     background: rgba(255, 0, 0, 0.2);
-    box-shadow: 0 0 12px rgba(255, 0, 0, 0.3);
+    box-shadow: 0 0 12px rgba(255, 0, 0, 0.15);
 }
 
 .btn-success {
     background: rgba(0, 255, 0, 0.1);
     color: var(--color-success);
-    border: 2px solid var(--color-success);
+    border: 1px solid var(--color-success);
 }
 
 .btn-success:hover:not(:disabled) {
     background: rgba(0, 255, 0, 0.2);
-    box-shadow: 0 0 12px rgba(0, 255, 0, 0.3);
+    box-shadow: 0 0 12px rgba(0, 255, 0, 0.15);
 }
 
 /* Canonical *solid*-fill button (as opposed to the outline .btn-primary
@@ -301,7 +326,7 @@ body {
 .form-select {
     width: 100%;
     padding: 10px 12px;
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     font-size: 1rem;
     transition: all 0.3s;
@@ -448,13 +473,11 @@ body {
 
 .tab:hover {
     color: var(--color-primary);
-    text-shadow: 0 0 8px var(--color-primary-glow);
 }
 
 .tab.active {
     color: var(--color-primary);
     border-bottom-color: var(--color-primary);
-    text-shadow: 0 0 8px var(--color-primary-glow);
 }
 
 .tab-content {
@@ -505,7 +528,7 @@ body {
     display: flex;
     width: 100%;
     max-width: 1400px;
-    height: calc(100vh - 140px);
+    height: 100%;
     gap: 0;
     position: relative;
 }
@@ -878,8 +901,8 @@ body {
         display: none;
     }
 
-    .chat-layout {
-        height: calc(100vh - 40px);
+    .pwa-install-btn {
+        display: none;
     }
 }
 
@@ -939,13 +962,11 @@ body {
 
 .tab:hover {
     color: var(--color-primary);
-    text-shadow: 0 0 8px var(--color-primary-glow);
 }
 
 .tab.active {
     color: var(--color-primary);
     border-bottom-color: var(--color-primary);
-    text-shadow: 0 0 8px var(--color-primary-glow);
 }
 
 /* Tab Content */
@@ -1045,7 +1066,7 @@ body {
 .btn-icon {
     padding: 10px 16px;
     background: var(--color-bg);
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     cursor: pointer;
     transition: all 0.2s;
@@ -1152,7 +1173,7 @@ body {
 /* Integration Cards */
 .integration-card {
     background: var(--color-surface);
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 20px;
     margin-bottom: 16px;
@@ -1483,7 +1504,7 @@ body {
 
 .banner-warning {
     background: var(--color-warning-bg);
-    border: 2px solid var(--color-warning);
+    border: 1px solid var(--color-warning);
     color: var(--color-warning);
 }
 
@@ -1606,7 +1627,7 @@ body {
 /* Danger Zone */
 .danger-zone {
     background: var(--color-error-bg);
-    border: 2px solid var(--color-error);
+    border: 1px solid var(--color-error);
     border-radius: 12px;
     padding: 20px;
 }
@@ -2051,7 +2072,7 @@ body {
 /* Tools Tab - Drag & Drop Zones */
 .tool-drop-zone {
     background: var(--color-surface);
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     margin-bottom: 1rem;
     transition: all 0.2s;

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -194,12 +194,23 @@ body {
     color: var(--color-primary);
 }
 
+/* Wraps .main-container (+ .site-footer, where present) as one column,
+   sibling to .navbar, so the desktop sidebar layout below can put the
+   navbar and this column side by side without the footer ending up next
+   to the nav instead of under the content. */
+.page-content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
 /* Main Content Container */
 .main-container {
     flex: 1;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     padding: 20px;
 }
 
@@ -799,6 +810,76 @@ body {
     }
 }
 
+/* Desktop: navbar becomes a persistent left rail instead of a top bar —
+   a more "app-like" desktop layout, and it stops the nav from eating
+   vertical space above every page's content. Below 769px it stays the
+   familiar top bar + hamburger dropdown, unchanged. */
+@media (min-width: 769px) {
+    body {
+        flex-direction: row;
+        align-items: stretch;
+    }
+
+    .navbar {
+        position: sticky;
+        top: 0;
+        align-self: flex-start;
+        flex-direction: column;
+        flex-shrink: 0;
+        width: 224px;
+        height: 100vh;
+        box-shadow: none;
+        border-bottom: none;
+        border-right: 1px solid var(--color-border);
+        padding: 20px 0;
+    }
+
+    .navbar-content {
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+        gap: 28px;
+        max-width: none;
+        height: 100%;
+        padding: 0 16px;
+    }
+
+    .navbar-brand {
+        padding: 0 4px;
+        font-size: 1.05rem;
+        white-space: nowrap;
+    }
+
+    .navbar-links {
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .nav-link {
+        padding: 10px 12px;
+        border-left: 3px solid transparent;
+        border-radius: 0 8px 8px 0;
+    }
+
+    /* Sleeker active state for a vertical rail: a left accent bar instead
+       of the horizontal nav's full box outline + glow. */
+    .nav-link.active {
+        background: rgba(0, 255, 0, 0.12);
+        border: none;
+        border-left: 3px solid var(--color-primary);
+        box-shadow: none;
+        padding-left: 9px;
+    }
+
+    .navbar-hamburger {
+        display: none;
+    }
+
+    .chat-layout {
+        height: calc(100vh - 40px);
+    }
+}
+
 /* ============================================================================
    SETTINGS PAGE STYLES
    ============================================================================ */
@@ -809,7 +890,7 @@ body {
     border-radius: 16px;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
     width: 100%;
-    max-width: 1000px;
+    max-width: 1200px;
     padding: 30px;
     min-height: 600px;
 }

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -105,7 +105,6 @@ body {
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--color-primary);
-    text-shadow: 0 0 10px var(--color-primary-glow);
     display: flex;
     align-items: center;
     gap: 12px;
@@ -115,10 +114,7 @@ body {
 .navbar-logo {
     width: 32px;
     height: 32px;
-}
-
-.navbar-brand-short {
-    display: none;
+    flex-shrink: 0;
 }
 
 .navbar-links {
@@ -170,34 +166,9 @@ body {
     stroke: currentColor;
 }
 
-/* Shared site footer, injected via js/components.js on non-chat pages */
-.site-footer {
-    margin-top: auto;
-    padding: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 16px;
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-    border-top: 1px solid var(--color-border);
-}
-
-.site-footer a {
-    color: var(--color-text-muted);
-    text-decoration: none;
-    transition: color 0.2s;
-}
-
-.site-footer a:hover {
-    color: var(--color-primary);
-}
-
-/* Wraps .main-container (+ .site-footer, where present) as one column,
-   sibling to .navbar, so the desktop sidebar layout below can put the
-   navbar and this column side by side without the footer ending up next
-   to the nav instead of under the content. */
+/* Wraps .main-container as its own column, sibling to .navbar, so the
+   desktop sidebar layout below can put the navbar and content side by
+   side. */
 .page-content {
     flex: 1;
     min-width: 0;
@@ -351,6 +322,27 @@ body {
 .form-textarea {
     resize: vertical;
     min-height: 100px;
+}
+
+/* Integration status banner (chat page) — built by js/chat.js */
+.integration-status {
+    padding: 8px 20px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 10px;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.8rem;
+}
+
+.integration-status-count {
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
+.integration-status-active {
+    color: var(--color-text-muted);
 }
 
 /* Toast Notifications */
@@ -545,25 +537,25 @@ body {
 
 .sidebar-header {
     padding: 16px 20px;
-    background: var(--color-primary-gradient);
-    color: var(--color-bg-darker);
+    background: var(--color-surface);
+    color: var(--color-text);
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid var(--color-primary);
+    border-bottom: 1px solid var(--color-border);
 }
 
 .sidebar-header h3 {
-    font-size: 1.1rem;
+    font-size: 1rem;
     font-weight: 600;
     margin: 0;
+    color: var(--color-primary);
 }
 
 .sidebar-close-btn {
     background: none;
     border: none;
-    color: var(--color-bg-darker);
-    font-size: 1.8rem;
+    color: var(--color-text-muted);
     cursor: pointer;
     padding: 0;
     width: 32px;
@@ -571,12 +563,13 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
-    transition: background 0.2s;
+    border-radius: 6px;
+    transition: all 0.2s;
 }
 
 .sidebar-close-btn:hover {
-    background: rgba(0, 0, 0, 0.3);
+    background: rgba(0, 255, 0, 0.1);
+    color: var(--color-primary);
 }
 
 .sidebar-filters {
@@ -591,16 +584,23 @@ body {
 .sidebar-filters input,
 .sidebar-filters select {
     padding: 8px 12px;
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     font-size: 0.9rem;
     font-family: inherit;
+    background: var(--color-bg-darker);
+    color: var(--color-text);
+}
+
+.sidebar-filters input::placeholder {
+    color: var(--color-text-muted);
 }
 
 .sidebar-filters input:focus,
 .sidebar-filters select:focus {
     outline: none;
     border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--color-primary-glow);
 }
 
 .sidebar-content {
@@ -692,7 +692,7 @@ body {
     border: none;
     cursor: pointer;
     font-size: 1.1rem;
-    color: #999;
+    color: var(--color-text-muted);
     padding: 0;
     width: 24px;
     height: 24px;
@@ -705,8 +705,8 @@ body {
 }
 
 .pin-button:hover {
-    background: rgba(0, 0, 0, 0.05);
-    color: #666;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--color-text);
 }
 
 .pin-button.pinned {
@@ -757,11 +757,13 @@ body {
 
 /* Sidebar Toggle Button */
 .sidebar-toggle-btn {
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid var(--color-bg-darker);
-    color: var(--color-bg-darker);
-    font-size: 1.2rem;
-    padding: 4px 12px;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 10px;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s;
@@ -769,8 +771,9 @@ body {
 }
 
 .sidebar-toggle-btn:hover {
-    background: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: rgba(0, 255, 0, 0.08);
 }
 
 .chat-header-left {

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -84,6 +84,14 @@ body {
     font-family: 'Courier New', 'Consolas', 'Monaco', 'Menlo', 'Liberation Mono', monospace;
     background: var(--color-bg);
     color: var(--color-text);
+    /* Was the 16px browser default, one size larger than the chat page's
+       text (which was tuned down to 0.9rem on its own). Every element
+       below that doesn't set its own font-size — table cells, paragraphs,
+       labels, help text — inherits this, so this one line is what keeps
+       Settings/Artifacts/Monitoring's "plain" text aligned with Chat's
+       instead of reading a size bigger. rem-based sizes elsewhere (h1s,
+       badges, etc.) are anchored to the root element and unaffected. */
+    font-size: 0.9rem;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -262,7 +270,7 @@ body {
     padding: 10px 20px;
     border: none;
     border-radius: 8px;
-    font-size: 1rem;
+    font-size: 0.9rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
@@ -355,7 +363,7 @@ body {
     padding: 10px 12px;
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    font-size: 1rem;
+    font-size: 0.9rem;
     transition: all 0.3s;
     font-family: inherit;
     background: var(--color-bg-darker);
@@ -1023,7 +1031,7 @@ body {
     padding: 12px 24px;
     background: none;
     border: none;
-    font-size: 1rem;
+    font-size: 0.9rem;
     font-weight: 500;
     color: var(--color-text);
     cursor: pointer;

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -21,6 +21,11 @@
     /* Colors - Text */
     --color-text: #ffffff;
     --color-text-muted: #cccccc;
+    /* Text color for content sitting on a solid --color-primary/--color-success/
+       --color-warning fill (near-black, not pure white/black) — the single
+       source of truth for "readable text on a bright accent background".
+       See issue #88: a solid green button with white text fails contrast. */
+    --color-on-primary: #0a0a0a;
 
     /* Colors - Borders */
     --color-border: #2e2e2e;
@@ -104,6 +109,7 @@ body {
     display: flex;
     align-items: center;
     gap: 12px;
+    text-decoration: none;
 }
 
 .navbar-logo {
@@ -121,12 +127,22 @@ body {
 }
 
 .nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     padding: 8px 16px;
     text-decoration: none;
     color: var(--color-text);
     border-radius: 8px;
     transition: all 0.2s;
     font-weight: 500;
+}
+
+.nav-link-icon {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    opacity: 0.85;
 }
 
 .nav-link:hover {
@@ -139,6 +155,43 @@ body {
     color: var(--color-primary);
     border: 1px solid var(--color-primary);
     box-shadow: 0 0 8px var(--color-primary-glow);
+}
+
+.nav-link.active .nav-link-icon {
+    opacity: 1;
+}
+
+/* Icon sprite <use> references throughout the app */
+.icon {
+    width: 1.1em;
+    height: 1.1em;
+    flex-shrink: 0;
+    fill: none;
+    stroke: currentColor;
+}
+
+/* Shared site footer, injected via js/components.js on non-chat pages */
+.site-footer {
+    margin-top: auto;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    border-top: 1px solid var(--color-border);
+}
+
+.site-footer a {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.site-footer a:hover {
+    color: var(--color-primary);
 }
 
 /* Main Content Container */
@@ -232,6 +285,21 @@ body {
 .btn-success:hover:not(:disabled) {
     background: rgba(0, 255, 0, 0.2);
     box-shadow: 0 0 12px rgba(0, 255, 0, 0.3);
+}
+
+/* Canonical *solid*-fill button (as opposed to the outline .btn-primary
+   above) — e.g. "Open URL", cron job row actions. Always pair a solid
+   --color-primary fill with --color-on-primary text, never white/black
+   literals, so this class of contrast bug (issue #88) can't recur. */
+.btn-solid {
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+}
+
+.btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-dark);
+    box-shadow: 0 0 12px var(--color-primary-glow);
+    transform: translateY(-2px);
 }
 
 /* Form Elements */
@@ -1649,7 +1717,7 @@ body {
 
 .open-url-btn {
     background: var(--color-primary);
-    color: #000;
+    color: var(--color-on-primary);
     padding: 0.75rem 1.5rem;
     border: none;
     border-radius: 0.5rem;

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -139,31 +139,33 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 16px;
+    padding: 7px 14px;
     text-decoration: none;
     color: var(--color-text);
     border-radius: 8px;
-    transition: all 0.2s;
+    font-size: 0.9rem;
     font-weight: 500;
+    transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
 }
 
 .nav-link-icon {
-    width: 16px;
-    height: 16px;
+    width: 15px;
+    height: 15px;
     flex-shrink: 0;
-    opacity: 0.85;
+    opacity: 0.75;
+    transition: opacity 0.25s ease;
 }
 
 .nav-link:hover {
-    background: rgba(0, 255, 0, 0.1);
+    background: rgba(0, 255, 0, 0.06);
     color: var(--color-primary);
 }
 
 .nav-link.active {
-    background: rgba(0, 255, 0, 0.2);
+    background: rgba(0, 255, 0, 0.12);
     color: var(--color-primary);
-    border: 1px solid var(--color-primary);
-    box-shadow: 0 0 8px var(--color-primary-glow);
+    border: 1px solid rgba(0, 255, 0, 0.35);
+    box-shadow: 0 0 6px var(--color-primary-glow);
 }
 
 .nav-link.active .nav-link-icon {
@@ -178,6 +180,31 @@ body {
     background: rgba(0, 255, 0, 0.1);
     border: 1px solid var(--color-primary);
     color: var(--color-primary);
+}
+
+/* Fold-in/out toggle for the desktop rail — hidden on mobile (the
+   top-bar layout has no rail to collapse). */
+.navbar-collapse-btn {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    padding: 7px 10px;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+.navbar-collapse-btn:hover {
+    background: rgba(0, 255, 0, 0.06);
+    color: var(--color-primary);
+}
+
+.navbar-collapse-icon {
+    transition: transform 0.2s ease;
 }
 
 /* Icon sprite <use> references throughout the app */
@@ -852,22 +879,23 @@ body {
         align-self: flex-start;
         flex-direction: column;
         flex-shrink: 0;
-        width: 224px;
+        width: 216px;
         height: 100vh;
         box-shadow: none;
         border-bottom: none;
         border-right: 1px solid var(--color-border);
-        padding: 20px 0;
+        padding: 16px 0;
+        transition: width 0.2s ease;
     }
 
     .navbar-content {
         flex-direction: column;
         align-items: stretch;
         justify-content: flex-start;
-        gap: 28px;
+        gap: 22px;
         max-width: none;
         height: 100%;
-        padding: 0 16px;
+        padding: 0 12px;
     }
 
     .navbar-brand {
@@ -878,23 +906,23 @@ body {
 
     .navbar-links {
         flex-direction: column;
-        gap: 2px;
+        gap: 1px;
     }
 
     .nav-link {
-        padding: 10px 12px;
+        padding: 7px 10px;
         border-left: 3px solid transparent;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 6px 6px 0;
     }
 
     /* Sleeker active state for a vertical rail: a left accent bar instead
        of the horizontal nav's full box outline + glow. */
     .nav-link.active {
-        background: rgba(0, 255, 0, 0.12);
+        background: rgba(0, 255, 0, 0.1);
         border: none;
         border-left: 3px solid var(--color-primary);
         box-shadow: none;
-        padding-left: 9px;
+        padding-left: 7px;
     }
 
     .navbar-hamburger {
@@ -903,6 +931,50 @@ body {
 
     .pwa-install-btn {
         display: none;
+    }
+
+    /* Fold-in/out toggle, pinned to the bottom of the rail */
+    .navbar-collapse-btn {
+        display: flex;
+        margin-top: auto;
+    }
+
+    /* Collapsed rail: icon-only, no labels */
+    .navbar.collapsed {
+        width: 60px;
+    }
+
+    .navbar.collapsed .navbar-content {
+        padding: 0 8px;
+        align-items: center;
+    }
+
+    .navbar.collapsed .navbar-brand,
+    .navbar.collapsed .nav-link,
+    .navbar.collapsed .navbar-collapse-btn {
+        justify-content: center;
+    }
+
+    .navbar.collapsed .nav-link {
+        width: 100%;
+        padding: 8px;
+        border-left: none;
+        border-radius: 6px;
+    }
+
+    .navbar.collapsed .nav-link.active {
+        padding-left: 8px;
+        border-left: none;
+        box-shadow: none;
+    }
+
+    .navbar.collapsed .nav-link-label,
+    .navbar.collapsed .pwa-install-btn span:not(.nav-link-icon) {
+        display: none;
+    }
+
+    .navbar.collapsed .navbar-collapse-icon {
+        transform: rotate(180deg);
     }
 }
 

--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -906,7 +906,7 @@ body {
 
     .navbar-links {
         flex-direction: column;
-        gap: 1px;
+        gap: 6px;
     }
 
     .nav-link {

--- a/src/ui/static/css/mobile.css
+++ b/src/ui/static/css/mobile.css
@@ -189,16 +189,6 @@ body.is-pwa {
         height: 28px;
     }
 
-    .navbar-brand {
-        font-size: 1.1rem;
-    }
-
-    /* The logo badge already renders "OA" — just drop the full wordmark
-       on mobile instead of swapping in a redundant second "OA" label. */
-    .navbar-brand-text {
-        display: none;
-    }
-
     /* Show hamburger, hide inline links */
     .navbar-hamburger {
         display: flex;

--- a/src/ui/static/css/mobile.css
+++ b/src/ui/static/css/mobile.css
@@ -193,12 +193,10 @@ body.is-pwa {
         font-size: 1.1rem;
     }
 
-    .navbar-brand span {
+    /* The logo badge already renders "OA" — just drop the full wordmark
+       on mobile instead of swapping in a redundant second "OA" label. */
+    .navbar-brand-text {
         display: none;
-    }
-
-    .navbar-brand .navbar-brand-short {
-        display: inline;
     }
 
     /* Show hamburger, hide inline links */

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -57,18 +57,19 @@
         }
 
         .chat-header {
-            background: linear-gradient(135deg, #00ff00 0%, #00aa00 100%);
-            color: var(--background-darker);
-            padding: 16px 20px;
+            background: var(--card-background);
+            color: var(--text-secondary);
+            padding: 14px 20px;
             display: flex;
             justify-content: space-between;
             align-items: center;
-            border-bottom: 1px solid var(--primary-color);
+            border-bottom: 1px solid var(--border-color);
         }
 
         .chat-header-title {
-            font-size: 1.25rem;
+            font-size: 1.05rem;
             font-weight: 600;
+            color: var(--text-primary);
         }
 
         .chat-header-actions {
@@ -78,22 +79,25 @@
         }
 
         .conversation-id {
-            font-size: 0.85rem;
-            opacity: 0.9;
+            font-size: 0.82rem;
+            color: var(--text-muted);
         }
 
         #newConversationBtn {
-            background: rgba(0, 0, 0, 0.2);
-            color: var(--background-darker);
-            border: 1px solid var(--background-darker);
-            padding: 6px 12px;
+            background: transparent;
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+            padding: 6px 14px;
             border-radius: 6px;
             cursor: pointer;
-            font-size: 0.9rem;
+            font-size: 0.85rem;
+            transition: all 0.2s;
         }
 
         #newConversationBtn:hover {
-            background: rgba(0, 0, 0, 0.3);
+            color: var(--primary-color);
+            border-color: var(--primary-color);
+            background: rgba(0, 255, 0, 0.08);
         }
 
         .chat-messages {
@@ -122,9 +126,9 @@
         }
 
         .message.user .message-content {
-            background: rgba(0, 255, 0, 0.15);
-            color: var(--primary-color);
-            border: 1px solid var(--primary-color);
+            background: rgba(0, 255, 0, 0.1);
+            color: var(--text-primary);
+            border: 1px solid rgba(0, 255, 0, 0.25);
         }
 
         .message.assistant .message-content {

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -675,27 +675,8 @@
     </style>
 </head>
 <body>
-    <!-- Navigation -->
-    <nav class="navbar">
-        <div class="navbar-content">
-            <div class="navbar-brand">
-                <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
-                <span>Open Assistant</span>
-                <span class="navbar-brand-short">OA</span>
-            </div>
-            <div class="navbar-links">
-                <a href="/" class="nav-link">Chat</a>
-                <a href="/artifacts" class="nav-link">Artifacts</a>
-                <a href="/settings" class="nav-link">Settings</a>
-                <a href="/monitoring" class="nav-link">Monitoring</a>
-            </div>
-            <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
-        </div>
-    </nav>
+    <!-- Navigation (rendered by js/components.js) -->
+    <div id="navbar-root"></div>
 
     <!-- Main Content -->
     <div class="main-container">
@@ -704,7 +685,9 @@
             <div class="conversation-sidebar" id="conversationSidebar">
                 <div class="sidebar-header">
                     <h3>Conversations</h3>
-                    <button class="sidebar-close-btn" id="sidebarCloseBtn">&times;</button>
+                    <button class="sidebar-close-btn" id="sidebarCloseBtn" aria-label="Close conversation history">
+                        <svg class="icon" aria-hidden="true"><use href="#icon-close"></use></svg>
+                    </button>
                 </div>
                 <div class="sidebar-filters">
                     <input type="text" id="conversationSearch" placeholder="Search messages..." />
@@ -729,7 +712,7 @@
                 <div class="chat-header">
                     <div class="chat-header-left">
                         <button id="toggleSidebarBtn" class="sidebar-toggle-btn" title="Toggle conversation history">
-                            ☰
+                            <svg class="icon" aria-hidden="true"><use href="#icon-menu"></use></svg>
                         </button>
                         <div class="chat-header-title">Chat</div>
                     </div>
@@ -775,7 +758,9 @@
     <!-- Cancel confirmation modal -->
     <div class="modal-overlay hidden" id="cancelModal" role="dialog" aria-modal="true" aria-labelledby="cancelModalTitle">
         <div class="modal-card">
-            <div class="modal-icon">⛔</div>
+            <div class="modal-icon">
+                <svg class="icon" style="width:1.6em;height:1.6em;color:var(--color-error)" aria-hidden="true"><use href="#icon-alert"></use></svg>
+            </div>
             <div class="modal-title" id="cancelModalTitle">Stop ongoing work?</div>
             <div class="modal-body">
                 This will cancel all background tasks for this conversation.
@@ -791,6 +776,7 @@
     <!-- Scripts -->
     <script src="/static/js/marked.min.js"></script>
     <script src="/static/js/purify.min.js"></script>
+    <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>
     <script src="/static/js/chat.js"></script>
     <script src="/static/js/pwa.js"></script>

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -122,6 +122,8 @@
             max-width: 70%;
             padding: 12px 16px;
             border-radius: 12px;
+            font-size: 0.9rem;
+            line-height: 1.6;
             word-wrap: break-word;
             white-space: pre-wrap;
         }
@@ -155,9 +157,9 @@
         #messageInput {
             flex: 1;
             padding: 12px 16px;
-            border: 2px solid var(--border-color);
+            border: 1px solid var(--border-color);
             border-radius: 24px;
-            font-size: 1rem;
+            font-size: 0.9rem;
             outline: none;
             transition: all 0.3s;
             resize: none;
@@ -174,12 +176,12 @@
         }
 
         #sendButton {
-            padding: 12px 24px;
+            padding: 10px 22px;
             background: rgba(0, 255, 0, 0.1);
             color: var(--primary-color);
-            border: 2px solid var(--primary-color);
+            border: 1px solid var(--primary-color);
             border-radius: 24px;
-            font-size: 1rem;
+            font-size: 0.9rem;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.2s;
@@ -564,12 +566,12 @@
 
         /* ── Cancel button ──────────────────────────────────────── */
         .cancel-btn {
-            padding: 12px 18px;
+            padding: 10px 18px;
             background: rgba(239, 68, 68, 0.1);
             color: #ef4444;
-            border: 2px solid #ef4444;
+            border: 1px solid #ef4444;
             border-radius: 24px;
-            font-size: 1rem;
+            font-size: 0.9rem;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.2s;

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -679,6 +679,7 @@
     <div id="navbar-root"></div>
 
     <!-- Main Content -->
+    <div class="page-content">
     <div class="main-container">
         <div class="chat-layout" id="chatLayout">
             <!-- Conversation Sidebar -->
@@ -753,6 +754,7 @@
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <!-- Cancel confirmation modal -->

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -46,7 +46,8 @@
             box-shadow: var(--shadow);
             border: 1px solid var(--border-color);
             width: 100%;
-            height: calc(100vh - 140px);
+            height: 100%;
+            min-height: 0;
             display: flex;
             flex-direction: column;
             overflow: hidden;

--- a/src/ui/static/js/chat.js
+++ b/src/ui/static/js/chat.js
@@ -51,43 +51,26 @@ async function loadIntegrationStatus() {
 }
 
 function displayIntegrationStatus(status) {
-    // Add a subtle indicator in the UI showing available integrations
+    // Add a subtle indicator in the UI showing available integrations.
+    // Themed via CSS (.integration-status in common.css) rather than
+    // inline styles, so it follows the app's dark palette instead of a
+    // hardcoded light-mode blue.
     const statusDiv = document.createElement('div');
     statusDiv.className = 'integration-status';
-    statusDiv.style.cssText = `
-        padding: 8px 12px;
-        margin: 8px 0;
-        background: rgba(59, 130, 246, 0.1);
-        border-radius: 6px;
-        font-size: 0.875rem;
-        color: #4b5563;
-    `;
 
     const toolCount = status.available_tools.length;
-    statusDiv.innerHTML = `
-        <div class="integration-badge" style="margin-bottom: 4px;">
-            🔌 ${toolCount} integration tool${toolCount !== 1 ? 's' : ''} available
-        </div>
-    `;
-
-    // Show which integrations are active
     const activeIntegrations = Object.entries(status.integrations)
         .filter(([_, info]) => info.available)
         .map(([name, _]) => name);
 
-    if (activeIntegrations.length > 0) {
-        statusDiv.innerHTML += `
-            <div class="active-integrations" style="font-size: 0.8rem; color: #6b7280;">
-                Active: ${activeIntegrations.join(', ')}
-            </div>
-        `;
-    } else {
-        statusDiv.innerHTML += `
-            <div class="active-integrations" style="font-size: 0.8rem; color: #9ca3af;">
-                No integrations configured. Configure them in Settings.
-            </div>
-        `;
-    }
+    const activeLine = activeIntegrations.length > 0
+        ? `<span class="integration-status-active">Active: ${escapeHtml(activeIntegrations.join(', '))}</span>`
+        : `<span class="integration-status-active">No integrations configured. Configure them in Settings.</span>`;
+
+    statusDiv.innerHTML = `
+        <span class="integration-status-count">${toolCount} integration tool${toolCount !== 1 ? 's' : ''} available</span>
+        ${activeLine}
+    `;
 
     // Insert at the top of chat container
     const chatContainer = chatMessages.parentElement;

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -1,0 +1,87 @@
+// Shared page chrome: navbar, footer, and icon sprite.
+//
+// The app has no server-side templating (FastAPI just serves static HTML
+// files — see src/main.py), so each page previously copy-pasted the navbar
+// markup, which let the 4 copies drift out of sync. This module injects the
+// shared chrome client-side instead: every page includes an empty
+// <div id="navbar-root"></div> (and, where appropriate, a
+// <div id="footer-root"></div>) placeholder, and this script fills them in
+// on DOMContentLoaded — before common.js's own DOMContentLoaded handler
+// runs setActiveNavLink()/initHamburgerMenu() against the injected markup,
+// as long as this script tag appears before common.js's in each page.
+
+const NAV_ITEMS = [
+    { href: '/', label: 'Chat', icon: 'chat' },
+    { href: '/artifacts', label: 'Artifacts', icon: 'artifacts' },
+    { href: '/settings', label: 'Settings', icon: 'settings' },
+    { href: '/monitoring', label: 'Monitoring', icon: 'monitoring' },
+];
+
+// A single inline SVG sprite sheet covering the small, fixed set of system
+// icons used across the app (nav, controls, status) — in place of the
+// previous mix of raw inline SVG, Unicode symbols, and emoji standing in
+// for icons.
+const ICON_SPRITE = `
+<svg xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
+    <symbol id="icon-chat" viewBox="0 0 24 24"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+    <symbol id="icon-artifacts" viewBox="0 0 24 24"><rect x="3" y="8" width="18" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M1 3h22v5H1z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><line x1="10" y1="13" x2="14" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="icon-settings" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82A1.65 1.65 0 0 0 3 13.09H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+    <symbol id="icon-monitoring" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+    <symbol id="icon-close" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="icon-menu" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="icon-alert" viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+</svg>`;
+
+function injectIconSprite() {
+    if (document.getElementById('oa-icon-sprite')) return;
+    const wrapper = document.createElement('div');
+    wrapper.id = 'oa-icon-sprite';
+    wrapper.innerHTML = ICON_SPRITE;
+    document.body.prepend(wrapper);
+}
+
+function renderNavbar() {
+    const root = document.getElementById('navbar-root');
+    if (!root) return;
+
+    const links = NAV_ITEMS.map(item => `
+        <a href="${item.href}" class="nav-link">
+            <svg class="nav-link-icon" aria-hidden="true"><use href="#icon-${item.icon}"></use></svg>
+            <span>${item.label}</span>
+        </a>`).join('');
+
+    root.outerHTML = `
+    <nav class="navbar">
+        <div class="navbar-content">
+            <a href="/" class="navbar-brand" aria-label="Open Assistant home">
+                <img src="/static/robot-logo.svg" alt="" class="navbar-logo">
+                <span>Open Assistant</span>
+                <span class="navbar-brand-short">OA</span>
+            </a>
+            <div class="navbar-links">${links}</div>
+            <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>`;
+}
+
+function renderFooter() {
+    const root = document.getElementById('footer-root');
+    if (!root) return;
+
+    const year = new Date().getFullYear();
+    root.outerHTML = `
+    <footer class="site-footer">
+        <span>&copy; ${year} Open Assistant</span>
+        <a href="https://github.com/open-assistant-org/open-assistant" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </footer>`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    injectIconSprite();
+    renderNavbar();
+    renderFooter();
+});

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -30,7 +30,10 @@ const ICON_SPRITE = `
     <symbol id="icon-menu" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
     <symbol id="icon-alert" viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
     <symbol id="icon-install" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><polyline points="7 10 12 15 17 10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="icon-panel-collapse" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="2"/><line x1="10" y1="4" x2="10" y2="20" stroke="currentColor" stroke-width="2"/><polyline points="7 9 5 12 7 15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
 </svg>`;
+
+const NAV_COLLAPSE_KEY = 'oa-nav-collapsed';
 
 function injectIconSprite() {
     if (document.getElementById('oa-icon-sprite')) return;
@@ -45,13 +48,20 @@ function renderNavbar() {
     if (!root) return;
 
     const links = NAV_ITEMS.map(item => `
-        <a href="${item.href}" class="nav-link">
+        <a href="${item.href}" class="nav-link" title="${item.label}">
             <svg class="nav-link-icon" aria-hidden="true"><use href="#icon-${item.icon}"></use></svg>
-            <span>${item.label}</span>
+            <span class="nav-link-label">${item.label}</span>
         </a>`).join('');
 
+    let collapsed = false;
+    try {
+        collapsed = localStorage.getItem(NAV_COLLAPSE_KEY) === '1';
+    } catch (e) {
+        // localStorage unavailable (private browsing, blocked storage) — default to expanded.
+    }
+
     root.outerHTML = `
-    <nav class="navbar">
+    <nav class="navbar${collapsed ? ' collapsed' : ''}">
         <div class="navbar-content">
             <a href="/" class="navbar-brand" aria-label="Open Assistant home">
                 <svg class="navbar-logo" viewBox="0 0 32 32" aria-hidden="true">
@@ -65,8 +75,34 @@ function renderNavbar() {
                 <span></span>
                 <span></span>
             </button>
+            <button class="navbar-collapse-btn" id="navCollapseBtn" title="${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}" aria-label="Toggle sidebar width">
+                <svg class="icon navbar-collapse-icon" aria-hidden="true"><use href="#icon-panel-collapse"></use></svg>
+                <span class="nav-link-label">Collapse</span>
+            </button>
         </div>
     </nav>`;
+
+    initNavbarCollapse();
+}
+
+// Desktop-only fold-in/out for the sidebar rail. Persisted in
+// localStorage so it stays put across the full-page navigations this
+// (framework-free, multi-page) app does between Chat/Artifacts/Settings/
+// Monitoring.
+function initNavbarCollapse() {
+    const btn = document.getElementById('navCollapseBtn');
+    const navbar = document.querySelector('.navbar');
+    if (!btn || !navbar) return;
+
+    btn.addEventListener('click', () => {
+        const collapsed = navbar.classList.toggle('collapsed');
+        btn.title = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
+        try {
+            localStorage.setItem(NAV_COLLAPSE_KEY, collapsed ? '1' : '0');
+        } catch (e) {
+            // Ignore — collapse state just won't persist this session.
+        }
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -29,6 +29,7 @@ const ICON_SPRITE = `
     <symbol id="icon-close" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
     <symbol id="icon-menu" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
     <symbol id="icon-alert" viewBox="0 0 24 24"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+    <symbol id="icon-install" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><polyline points="7 10 12 15 17 10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
 </svg>`;
 
 function injectIconSprite() {
@@ -57,7 +58,6 @@ function renderNavbar() {
                     <rect x="2" y="2" width="28" height="28" rx="5" fill="var(--color-bg-darker)" stroke="var(--color-primary)" stroke-width="2"></rect>
                     <text x="16" y="21" font-family="monospace" font-size="12" font-weight="bold" fill="var(--color-primary)" text-anchor="middle">OA</text>
                 </svg>
-                <span class="navbar-brand-text">Open Assistant</span>
             </a>
             <div class="navbar-links">${links}</div>
             <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -53,11 +53,14 @@ function renderNavbar() {
             <span class="nav-link-label">${item.label}</span>
         </a>`).join('');
 
-    let collapsed = false;
+    // Collapsed by default — an explicit '0' is the only way to get the
+    // expanded rail, so a first-time visitor (or one with storage blocked)
+    // sees the compact icon-only sidebar.
+    let collapsed = true;
     try {
-        collapsed = localStorage.getItem(NAV_COLLAPSE_KEY) === '1';
+        collapsed = localStorage.getItem(NAV_COLLAPSE_KEY) !== '0';
     } catch (e) {
-        // localStorage unavailable (private browsing, blocked storage) — default to expanded.
+        // localStorage unavailable (private browsing, blocked storage) — default to collapsed.
     }
 
     root.outerHTML = `

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -1,14 +1,13 @@
-// Shared page chrome: navbar, footer, and icon sprite.
+// Shared page chrome: navbar and icon sprite.
 //
 // The app has no server-side templating (FastAPI just serves static HTML
 // files — see src/main.py), so each page previously copy-pasted the navbar
 // markup, which let the 4 copies drift out of sync. This module injects the
 // shared chrome client-side instead: every page includes an empty
-// <div id="navbar-root"></div> (and, where appropriate, a
-// <div id="footer-root"></div>) placeholder, and this script fills them in
-// on DOMContentLoaded — before common.js's own DOMContentLoaded handler
-// runs setActiveNavLink()/initHamburgerMenu() against the injected markup,
-// as long as this script tag appears before common.js's in each page.
+// <div id="navbar-root"></div> placeholder, and this script fills it in on
+// DOMContentLoaded — before common.js's own DOMContentLoaded handler runs
+// setActiveNavLink()/initHamburgerMenu() against the injected markup, as
+// long as this script tag appears before common.js's in each page.
 
 const NAV_ITEMS = [
     { href: '/', label: 'Chat', icon: 'chat' },
@@ -54,9 +53,11 @@ function renderNavbar() {
     <nav class="navbar">
         <div class="navbar-content">
             <a href="/" class="navbar-brand" aria-label="Open Assistant home">
-                <img src="/static/robot-logo.svg" alt="" class="navbar-logo">
-                <span>Open Assistant</span>
-                <span class="navbar-brand-short">OA</span>
+                <svg class="navbar-logo" viewBox="0 0 32 32" aria-hidden="true">
+                    <rect x="2" y="2" width="28" height="28" rx="5" fill="var(--color-bg-darker)" stroke="var(--color-primary)" stroke-width="2"></rect>
+                    <text x="16" y="21" font-family="monospace" font-size="12" font-weight="bold" fill="var(--color-primary)" text-anchor="middle">OA</text>
+                </svg>
+                <span class="navbar-brand-text">Open Assistant</span>
             </a>
             <div class="navbar-links">${links}</div>
             <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
@@ -68,20 +69,7 @@ function renderNavbar() {
     </nav>`;
 }
 
-function renderFooter() {
-    const root = document.getElementById('footer-root');
-    if (!root) return;
-
-    const year = new Date().getFullYear();
-    root.outerHTML = `
-    <footer class="site-footer">
-        <span>&copy; ${year} Open Assistant</span>
-        <a href="https://github.com/open-assistant-org/open-assistant" target="_blank" rel="noopener noreferrer">GitHub</a>
-    </footer>`;
-}
-
 document.addEventListener('DOMContentLoaded', () => {
     injectIconSprite();
     renderNavbar();
-    renderFooter();
 });

--- a/src/ui/static/js/pwa.js
+++ b/src/ui/static/js/pwa.js
@@ -93,15 +93,15 @@ function showInstallButton() {
     installButton = document.getElementById('installAppBtn');
 
     if (!installButton) {
-        // Create install button dynamically
+        // Create install button dynamically. Styled via .pwa-install-btn in
+        // common.css (which also hides it on desktop — installing "an app"
+        // is a mobile-home-screen affordance there, not a desktop one).
         installButton = document.createElement('button');
         installButton.id = 'installAppBtn';
-        installButton.className = 'nav-link';
-        installButton.textContent = '📱 Install';
-        installButton.style.cssText = `
-            background: rgba(0, 255, 0, 0.1);
-            border: 1px solid #00ff00;
-            color: #00ff00;
+        installButton.className = 'nav-link pwa-install-btn';
+        installButton.innerHTML = `
+            <svg class="nav-link-icon" aria-hidden="true"><use href="#icon-install"></use></svg>
+            <span>Install</span>
         `;
 
         // Add to navbar
@@ -112,7 +112,11 @@ function showInstallButton() {
     }
 
     if (installButton) {
-        installButton.style.display = 'inline-block';
+        // Clear any inline override from a previous hideInstallButton()
+        // call and let CSS decide (including hiding it on desktop via
+        // .pwa-install-btn's media query in common.css) rather than
+        // forcing it visible here.
+        installButton.style.removeProperty('display');
         installButton.addEventListener('click', promptInstall);
     }
 }

--- a/src/ui/static/monitoring.html
+++ b/src/ui/static/monitoring.html
@@ -778,6 +778,7 @@
 <body>
     <div id="navbar-root"></div>
 
+    <div class="page-content">
     <div class="main-container">
         <div class="monitoring-container">
             <div class="monitoring-header">
@@ -963,6 +964,7 @@
     </div>
 
     <div id="footer-root"></div>
+    </div>
 
     <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>

--- a/src/ui/static/monitoring.html
+++ b/src/ui/static/monitoring.html
@@ -192,7 +192,7 @@
             font-size: 0.8rem;
             cursor: pointer;
             background: var(--primary-color);
-            color: white;
+            color: var(--color-on-primary);
             transition: opacity 0.2s;
         }
 
@@ -202,6 +202,7 @@
 
         .job-action-btn.btn-danger {
             background: var(--error-color);
+            color: #fff;
         }
 
         .job-action-btn.btn-warning {
@@ -406,6 +407,8 @@
             line-height: 1;
             cursor: pointer;
             padding: 0 4px;
+            display: inline-flex;
+            align-items: center;
             transition: color 0.2s;
         }
 
@@ -471,7 +474,7 @@
             height: 26px;
             border-radius: 50%;
             background: var(--primary-color);
-            color: #05130a;
+            color: var(--color-on-primary);
             font-weight: 700;
             font-size: 0.85rem;
             display: flex;
@@ -773,26 +776,7 @@
     </style>
 </head>
 <body>
-    <nav class="navbar">
-        <div class="navbar-content">
-            <div class="navbar-brand">
-                <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
-                <span>Open Assistant</span>
-                <span class="navbar-brand-short">OA</span>
-            </div>
-            <div class="navbar-links">
-                <a href="/" class="nav-link">Chat</a>
-                <a href="/artifacts" class="nav-link">Artifacts</a>
-                <a href="/settings" class="nav-link">Settings</a>
-                <a href="/monitoring" class="nav-link">Monitoring</a>
-            </div>
-            <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
-        </div>
-    </nav>
+    <div id="navbar-root"></div>
 
     <div class="main-container">
         <div class="monitoring-container">
@@ -967,7 +951,9 @@
         <div class="modal-content recipe-graph-modal-content">
             <div class="modal-header" style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
                 <span id="graphModalTitle">Recipe Flow</span>
-                <button class="modal-close-btn" onclick="closeRecipeGraphModal()" aria-label="Close">&times;</button>
+                <button class="modal-close-btn" onclick="closeRecipeGraphModal()" aria-label="Close">
+                    <svg class="icon" aria-hidden="true"><use href="#icon-close"></use></svg>
+                </button>
             </div>
             <div class="modal-body">
                 <div id="recipeGraphMeta" class="recipe-graph-meta"></div>
@@ -976,6 +962,9 @@
         </div>
     </div>
 
+    <div id="footer-root"></div>
+
+    <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>
     <script>
         // State management

--- a/src/ui/static/monitoring.html
+++ b/src/ui/static/monitoring.html
@@ -962,8 +962,6 @@
             </div>
         </div>
     </div>
-
-    <div id="footer-root"></div>
     </div>
 
     <script src="/static/js/components.js"></script>

--- a/src/ui/static/settings.html
+++ b/src/ui/static/settings.html
@@ -41,6 +41,7 @@
 <body>
     <div id="navbar-root"></div>
 
+    <div class="page-content">
     <div class="main-container">
         <div class="settings-container">
             <div class="settings-header">
@@ -580,6 +581,7 @@
     </div>
 
     <div id="footer-root"></div>
+    </div>
 
     <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js"></script>
     <script src="/static/js/components.js"></script>

--- a/src/ui/static/settings.html
+++ b/src/ui/static/settings.html
@@ -39,26 +39,7 @@
     <link rel="stylesheet" href="/static/css/mobile.css">
 </head>
 <body>
-    <nav class="navbar">
-        <div class="navbar-content">
-            <div class="navbar-brand">
-                <img src="/static/robot-logo.svg" alt="Logo" class="navbar-logo">
-                <span>Open Assistant</span>
-                <span class="navbar-brand-short">OA</span>
-            </div>
-            <div class="navbar-links">
-                <a href="/" class="nav-link">Chat</a>
-                <a href="/artifacts" class="nav-link">Artifacts</a>
-                <a href="/settings" class="nav-link active">Settings</a>
-                <a href="/monitoring" class="nav-link">Monitoring</a>
-            </div>
-            <button class="navbar-hamburger" id="navHamburger" aria-label="Toggle navigation" aria-expanded="false">
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
-        </div>
-    </nav>
+    <div id="navbar-root"></div>
 
     <div class="main-container">
         <div class="settings-container">
@@ -598,7 +579,10 @@
         </div>
     </div>
 
+    <div id="footer-root"></div>
+
     <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js"></script>
+    <script src="/static/js/components.js"></script>
     <script src="/static/js/common.js"></script>
     <script src="/static/js/settings.js"></script>
     <script src="/static/js/pwa.js"></script>

--- a/src/ui/static/settings.html
+++ b/src/ui/static/settings.html
@@ -579,8 +579,6 @@
             </div>
         </div>
     </div>
-
-    <div id="footer-root"></div>
     </div>
 
     <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js"></script>


### PR DESCRIPTION
## Summary

Started as a contrast-only fix for #88 (white text on a green button) and grew into a full pass on the web UI's visual design and the technical debt behind it — the shared chrome was copy-pasted across all four pages, which is exactly how the #88 bug happened in the first place (two pages redefined the same button class with different, wrong text colors).

## Issue #88 fix (root cause, not a patch)

- Added a `--color-on-primary` design token and used it everywhere text sits on a solid green/primary fill, instead of three divergent hardcoded near-black/white values scattered per page.
- Fixes the reported `monitoring.html` `.job-action-btn` (white-on-green) and its `.btn-warning` sibling, and migrates the already-correct `artifacts.html` button and `.open-url-btn` onto the same token so this class of bug can't come back.

## Layout: desktop left sidebar

- The navbar is now a persistent, collapsible left rail on desktop (≥769px) instead of a top bar — collapses to a 60px icon-only strip via a toggle pinned to the bottom, state persisted in `localStorage`, **collapsed by default**. Mobile is untouched: still the familiar top bar + hamburger dropdown.
- Content no longer vertically centers on short pages (was leaving large wasted top/bottom gaps on Settings/Monitoring); now top-aligns properly, and pages use their available width more fully.
- The chat page's "fill the rest of the screen" sizing was rebuilt on real flexbox stretching (`height: 100%` chain) instead of `calc(100vh - 140px)`-style magic-number arithmetic that silently drifted whenever spacing changed.

## Shared chrome, de-duplicated

- New `src/ui/static/js/components.js` renders the navbar (and previously a footer, since removed per feedback) into a `<div id="navbar-root">` placeholder on each page, replacing ~23 lines of copy-pasted markup per file with one source of truth.
- Added a small inline SVG icon sprite, replacing the previous mix of raw SVG, Unicode glyphs (☰, ×, ⛔), and emoji in the nav, sidebar controls, and modals.
- Replaced the robot logo + "Open Assistant" wordmark with a compact "OA" badge mark, used consistently everywhere (wordmark dropped entirely, not just on mobile).

## Visual design pass

- Toned down the "neon terminal" feel: dimmed the shared glow token every hover/focus effect derives from, dropped glowing text-shadow on tabs, thinned buttons/inputs from 2px to 1px borders, softened nav hover/active highlights with smoother transitions.
- Reworked the chat page specifically: the chat header was a full-bleed bright green gradient bar, now a flat dark header with green used only as a small accent; the conversation history panel's search/filter inputs had no background/text color set at all and rendered as plain white boxes on the dark page — now properly themed with a focus ring; user message bubbles softened.
- The "N integration tools available" banner was built with hardcoded inline light-mode styles (light blue background, gray text) that clashed with the dark theme — rewritten to themed CSS.
- Base font size aligned across all four pages — Chat's text had been tuned down in isolation while Settings/Artifacts/Monitoring's shared button/tab/form-field/table text was still a size larger; now consistent everywhere via one root-level change, with headings unaffected.
- The PWA "Install" nav entry is a mobile home-screen affordance, hidden on desktop; its emoji swapped for the icon sprite.

## Verification

Ran the app locally end-to-end and screenshotted all four pages at desktop and mobile widths after each change (navbar dedup, sidebar layout, chat rework, collapse toggle + persistence across reload, font-size alignment), including driving the chat sidebar toggle, cancel modal, and PWA install-button visibility via a simulated `beforeinstallprompt`.