### PR TITLE
Fix managed-instance navigation losing the path prefix after UI redesign

### DIFF
--- a/src/api/mcp.py
+++ b/src/api/mcp.py
@@ -29,6 +29,19 @@ def _get_mcp_service(request: Request):
     return mcp_service
 
 
+def _redirect_to_settings(request: Request, query: str) -> RedirectResponse:
+    """302 back to the settings page, preserving any reverse-proxy path prefix.
+
+    When the app runs behind a prefix-stripping reverse proxy (signalled via
+    the standard X-Forwarded-Prefix header), an absolute-path Location would
+    drop the prefix and send the browser outside the app — so prepend the
+    prefix when it is present. Without a proxy the header is absent and the
+    redirect is the plain absolute path.
+    """
+    prefix = request.headers.get("x-forwarded-prefix", "").rstrip("/")
+    return RedirectResponse(f"{prefix}/settings?{query}", status_code=302)
+
+
 @router.get("", response_model=list[McpServerListItem])
 async def list_servers(request: Request) -> list[McpServerListItem]:
     """List all configured MCP servers with their state."""
@@ -186,15 +199,15 @@ async def oauth_callback(
     if error:
         desc = error_description or error
         logger.warning(f"OAuth callback received error: {error} — {desc}")
-        return RedirectResponse(f"/settings?mcp_error={desc}", status_code=302)
+        return _redirect_to_settings(request, f"mcp_error={desc}")
 
     if not code or not state:
-        return RedirectResponse("/settings?mcp_error=missing+code+or+state", status_code=302)
+        return _redirect_to_settings(request, "mcp_error=missing+code+or+state")
 
     mcp_service = _get_mcp_service(request)
     try:
         server_id = await mcp_service.oauth_callback(code, state)
-        return RedirectResponse(f"/settings?mcp_connected={server_id}", status_code=302)
+        return _redirect_to_settings(request, f"mcp_connected={server_id}")
     except Exception as e:
         logger.error(f"OAuth callback failed: {e}", exc_info=True)
-        return RedirectResponse(f"/settings?mcp_error={str(e)[:200]}", status_code=302)
+        return _redirect_to_settings(request, f"mcp_error={str(e)[:200]}")

--- a/src/ui/static/js/components.js
+++ b/src/ui/static/js/components.js
@@ -16,6 +16,13 @@ const NAV_ITEMS = [
     { href: '/monitoring', label: 'Monitoring', icon: 'monitoring' },
 ];
 
+// These links are built at runtime, so the managed platform's sub_filter
+// (which only rewrites href/src/action attributes in the HTML it serves)
+// can never prefix them — prefix here instead, like every other
+// browser-initiated URL in the app (APIClient, PWA, service worker).
+// Injected as the first element of <head> before any script runs.
+const INSTANCE_BASE = window.INSTANCE_BASE_PATH || '';
+
 // A single inline SVG sprite sheet covering the small, fixed set of system
 // icons used across the app (nav, controls, status) — in place of the
 // previous mix of raw inline SVG, Unicode symbols, and emoji standing in
@@ -48,7 +55,7 @@ function renderNavbar() {
     if (!root) return;
 
     const links = NAV_ITEMS.map(item => `
-        <a href="${item.href}" class="nav-link" title="${item.label}">
+        <a href="${INSTANCE_BASE}${item.href}" class="nav-link" title="${item.label}">
             <svg class="nav-link-icon" aria-hidden="true"><use href="#icon-${item.icon}"></use></svg>
             <span class="nav-link-label">${item.label}</span>
         </a>`).join('');
@@ -66,7 +73,7 @@ function renderNavbar() {
     root.outerHTML = `
     <nav class="navbar${collapsed ? ' collapsed' : ''}">
         <div class="navbar-content">
-            <a href="/" class="navbar-brand" aria-label="Open Assistant home">
+            <a href="${INSTANCE_BASE}/" class="navbar-brand" aria-label="Open Assistant home">
                 <svg class="navbar-logo" viewBox="0 0 32 32" aria-hidden="true">
                     <rect x="2" y="2" width="28" height="28" rx="5" fill="var(--color-bg-darker)" stroke="var(--color-primary)" stroke-width="2"></rect>
                     <text x="16" y="21" font-family="monospace" font-size="12" font-weight="bold" fill="var(--color-primary)" text-anchor="middle">OA</text>

--- a/src/ui/static/js/settings.js
+++ b/src/ui/static/js/settings.js
@@ -2679,7 +2679,10 @@ async function createMcpServer() {
 // ============================================================================
 
 async function connectMcpOAuth(serverId) {
-    const redirectUri = `${window.location.origin}/api/mcp/oauth/callback`;
+    // Include INSTANCE_BASE_PATH so the callback routes back through the
+    // instance on path-routed managed deployments instead of the management
+    // backend (sub_filter can't rewrite this — it's built in JS at runtime).
+    const redirectUri = `${window.location.origin}${window.INSTANCE_BASE_PATH || ''}/api/mcp/oauth/callback`;
     try {
         const resp = await api.post(`/api/mcp/${serverId}/oauth/start`, { redirect_uri: redirectUri });
         // Redirect the browser to the authorization endpoint.

--- a/src/ui/static/service-worker.js
+++ b/src/ui/static/service-worker.js
@@ -7,7 +7,9 @@
  * prefixes (/i/{slug}/) in managed deployments.
  */
 
-const CACHE_VERSION = 'v3';
+// v4: components.js nav links now carry the INSTANCE_BASE_PATH prefix
+// (managed instances navigated to /settings etc. instead of /i/{slug}/settings).
+const CACHE_VERSION = 'v4';
 const CACHE_NAME = `personal-assistant-${CACHE_VERSION}`;
 
 // Derive base path from the SW's own registration scope.


### PR DESCRIPTION
The UI redesign moved the navbar from static HTML into runtime-injected markup (js/components.js). sub_filter only rewrites href/src/action attributes in the HTML it serves, so it never sees markup the browser generates afterward — nav links rendered as root-absolute /settings, /monitoring etc. and 404'd on deployments served under a path prefix.

Restore correct routing on all legs that sub_filter cannot cover:

- components.js: prefix nav and brand links with INSTANCE_BASE_PATH, same pattern as APIClient/PWA/service worker
- settings.js: include the base path in the MCP OAuth redirect_uri
- mcp.py: honor X-Forwarded-Prefix in OAuth callback redirects so Location headers keep the prefix behind a prefix-stripping proxy
- service-worker.js: bump CACHE_VERSION so cache-first /static/ assets propagate the fixed components.js