### PR TITLE
Fix scrolling behavior for tall page content

### DIFF
--- a/src/ui/static/css/common.css
+++ b/src/ui/static/css/common.css
@@ -226,13 +226,22 @@ body {
 
 /* Wraps .main-container as its own column, sibling to .navbar, so the
    desktop sidebar layout below can put the navbar and content side by
-   side. */
+   side.
+
+   overflow-y: auto makes this the scroll container for page content,
+   instead of leaving the whole document to grow/scroll. Without it, tall
+   content (long Settings/Monitoring pages in particular) gets squeezed
+   into the min-height: 0 box below rather than properly scrolling — the
+   document's scrollable height doesn't extend to fit it, so scrolling is
+   erratic and the sticky .navbar (a flex sibling, unaffected by scrolling
+   *inside* this container) appears to scroll away instead of staying put. */
 .page-content {
     flex: 1;
     min-width: 0;
     min-height: 0;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
 }
 
 /* Main Content Container */


### PR DESCRIPTION
## Summary
Fixed erratic scrolling behavior on pages with tall content (such as Settings and Monitoring pages) by making `.page-content` the scroll container instead of the entire document.

## Changes
- Added `overflow-y: auto` to `.page-content` CSS class to establish it as the scroll container for page content
- Updated comments to document the scrolling behavior and explain why this property is necessary

## Implementation Details
Previously, the document would grow to accommodate tall content, causing the scrollable height to not extend properly. This resulted in:
- Erratic scrolling behavior on long pages
- The sticky navbar appearing to scroll away instead of remaining fixed

By setting `overflow-y: auto` on `.page-content`, the container now properly handles its own scrolling while the navbar (a flex sibling) remains unaffected and stays in place as intended.