### PR TITLE
Add support for query-parameter authentication in plugins

### DIFF
--- a/docs/plugin-schema.md
+++ b/docs/plugin-schema.md
@@ -61,9 +61,10 @@ Plugins are JSON files that define lightweight REST API integrations. Each plugi
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | `"bearer"` \| `"header"` \| `"basic"` \| `"api_key_with_jwt"` | Auth mechanism. |
+| `type` | `"bearer"` \| `"header"` \| `"basic"` \| `"api_key_with_jwt"` \| `"query"` | Auth mechanism. |
 | `header_name` | string | Required when `type = "header"`. The HTTP header name (e.g. `X-API-Key`). |
 | `fixed_password` | string | Optional, `type = "basic"` only. Hardcodes the password — the user only provides a token/username. Example: Toggl uses `"api_token"`. |
+| `query_param_name` | string | Optional, `type = "query"` only. The query-string parameter name to send the token as (e.g. `"api_key"`). Defaults to `"api_key"`. |
 | `api_key_header` | string | `type = "api_key_with_jwt"` only. **Optional.** Header name for the static API key (e.g. `"X-apikey"`). Omit for pure JWT login flows. |
 | `token_endpoint` | string | `type = "api_key_with_jwt"` only. Path to POST credentials to (default: `"/token"`). |
 | `token_field` | string | `type = "api_key_with_jwt"` only. JSON field in the login response containing the JWT (default: `"access_token"`). |
@@ -74,6 +75,8 @@ Plugins are JSON files that define lightweight REST API integrations. Each plugi
 **`header`** — Sends `{header_name}: {token}`. User provides one secret field (token).
 
 **`basic`** — Sends `Authorization: Basic base64(username:password)`. User provides username + password. If `fixed_password` is set, only a single token field is shown.
+
+**`query`** — Appends `?{query_param_name}={token}` to every request's query string instead of sending a header. User provides one secret field (token). Use this for APIs that reject credentials sent as a header and require the key as a URL parameter (e.g. needing `?api_key=...`). The value is merged with any endpoint-defined query parameters, so it always accompanies the rest of the request.
 
 **`api_key_with_jwt`** — For APIs that use a username + password login to obtain a short-lived JWT. Covers two patterns:
 
@@ -97,7 +100,10 @@ Non-secret values needed to build request URLs (e.g. organisation name, instance
 | `sensitive` | boolean | | If `true`, stored encrypted in credentials instead of settings. Default: `false`. |
 | `placeholder` | string | | Input placeholder text. |
 
-Config field values are automatically substituted into URL paths and `base_url`:
+Config field values are automatically substituted into URL paths and `base_url` — this works
+whether the field is plain (stored in settings) or `"sensitive": true` (stored encrypted in
+credentials). Use a sensitive config field for a secret that an API expects embedded directly in
+the URL path, e.g. `/v1/{api_key}/report`:
 
 ```json
 "base_url": "https://dev.azure.com",
@@ -218,6 +224,61 @@ JSON array — no stringified `"[75205]"` workaround, and no runtime coercion.
   "header_name": "X-API-Key"
 }
 ```
+
+### API key as a query parameter
+
+Some APIs require the API key to be part of the request's query string (or path) rather than
+a header, rejecting a header-based key outright and only accepting e.g. `?api_key=...`:
+
+```json
+{
+  "id": "my_data_api",
+  "display_name": "My Data API",
+  "description": "Analytics connector that authenticates via a query-string API key.",
+  "icon": "🔧",
+  "base_url": "https://api.mydataservice.example.com",
+  "auth": {
+    "type": "query",
+    "query_param_name": "api_key"
+  },
+  "config_fields": [],
+  "endpoints": [
+    {
+      "name": "get_report",
+      "display_name": "Get Report",
+      "description": "Retrieve report data for a date range.",
+      "method": "GET",
+      "path": "/report",
+      "parameters": [
+        {
+          "name": "fields",
+          "in": "query",
+          "type": "string",
+          "description": "Comma-separated list of fields to return (e.g. 'date,spend,clicks').",
+          "required": true
+        },
+        {
+          "name": "date_preset",
+          "in": "query",
+          "type": "string",
+          "description": "Relative date range, e.g. 'last_30d' or 'this_month'.",
+          "required": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+The user provides one secret field (**API Token / Secret** in Settings → Plugins), which is sent
+as `?api_key={token}` on every request — merged with the endpoint's own query parameters, so a
+call to `get_report` ends up as `/report?fields=date,spend&date_preset=last_30d&api_key=...`.
+
+If the target API instead expects the key embedded in the URL *path* (e.g. `/v1/{api_key}/report`)
+rather than the query string, don't use `auth.type = "query"` for that — model the key as a
+required `config_fields` entry with `"sensitive": true` and reference it in `path` or `base_url`
+as `{api_key}` (see [`config_fields` items](#config_fields-items) above); it's stored encrypted
+just like any other credential.
 
 ### Basic auth with fixed password (Toggl-style)
 

--- a/src/models/plugin.py
+++ b/src/models/plugin.py
@@ -86,11 +86,14 @@ class PluginEndpoint(BaseModel):
 class PluginAuth(BaseModel):
     """Authentication configuration for a plugin."""
 
-    type: Literal["bearer", "header", "basic", "api_key_with_jwt"]
+    type: Literal["bearer", "header", "basic", "api_key_with_jwt", "query"]
     # For type="header": the HTTP header name to send the token as
     header_name: Optional[str] = None
     # For type="basic" with a fixed password (e.g. Toggl uses "api_token" as password)
     fixed_password: Optional[str] = None
+    # For type="query": the query-string parameter name to send the token as
+    # (e.g. "api_key"). Defaults to "api_key" when unset.
+    query_param_name: Optional[str] = None
     # For type="api_key_with_jwt": static API key header (e.g. "X-apikey")
     api_key_header: Optional[str] = None
     # For type="api_key_with_jwt": path to POST credentials to (e.g. "/token")

--- a/src/plugins/openapi_import.py
+++ b/src/plugins/openapi_import.py
@@ -128,9 +128,11 @@ def _auth(spec: Dict[str, Any], warnings: List[str]) -> Dict[str, Any]:
             return {"type": "bearer"}
         if stype == "apikey":
             location = (scheme.get("in") or "").lower()
-            header_name = scheme.get("name") or "X-API-Key"
+            param_name = scheme.get("name") or "X-API-Key"
             if location == "header":
-                return {"type": "header", "header_name": header_name}
+                return {"type": "header", "header_name": param_name}
+            if location == "query":
+                return {"type": "query", "query_param_name": param_name}
             warnings.append(
                 f"Security scheme {name!r} sends an API key in '{location}', which the plugin "
                 "schema can't represent as auth; defaulted to bearer — adjust manually."

--- a/src/plugins/plugin_schema.json
+++ b/src/plugins/plugin_schema.json
@@ -39,12 +39,16 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["bearer", "header", "basic", "api_key_with_jwt"],
-          "description": "Authentication mechanism. 'bearer' → Authorization: Bearer {token}. 'header' → {header_name}: {token}. 'basic' → Authorization: Basic base64(username:password). 'api_key_with_jwt' → static {api_key_header} + JWT obtained via POST {token_endpoint}."
+          "enum": ["bearer", "header", "basic", "api_key_with_jwt", "query"],
+          "description": "Authentication mechanism. 'bearer' → Authorization: Bearer {token}. 'header' → {header_name}: {token}. 'basic' → Authorization: Basic base64(username:password). 'api_key_with_jwt' → static {api_key_header} + JWT obtained via POST {token_endpoint}. 'query' → {query_param_name}={token} appended to the query string of every request."
         },
         "header_name": {
           "type": "string",
           "description": "Required when type is 'header'. The HTTP header name to use."
+        },
+        "query_param_name": {
+          "type": "string",
+          "description": "Optional, for type 'query'. The query-string parameter name to send the token as (e.g. 'api_key'). Defaults to 'api_key'."
         },
         "fixed_password": {
           "type": "string",

--- a/src/services/plugin_service.py
+++ b/src/services/plugin_service.py
@@ -224,9 +224,19 @@ class PluginService(BaseService):
         # Credentials are stored as {"credential_type": ..., "credential_data": {...}, ...}
         creds = raw_creds.get("credential_data", raw_creds)
 
-        # Build auth headers (may perform an async JWT fetch for api_key_with_jwt)
+        # Sensitive config field values (e.g. a secret meant to be interpolated into the
+        # URL path rather than sent as a header) live in credentials, not settings — merge
+        # them in alongside the non-sensitive ones so {field_key} placeholders in base_url
+        # and path resolve either way.
+        url_values: Dict[str, Any] = dict(config_values)
+        for field in defn.config_fields:
+            if field.sensitive and field.key in creds:
+                url_values[field.key] = creds[field.key]
+
+        # Build auth headers/query params (may perform an async JWT fetch for api_key_with_jwt)
         headers: Dict[str, str] = {"Content-Type": "application/json"}
-        headers.update(await self._resolve_auth_headers(plugin_id, defn, creds, defn.base_url))
+        auth_headers, auth_query_params = await self._resolve_auth(plugin_id, defn, creds, defn.base_url)
+        headers.update(auth_headers)
 
         # Resolve base URL (may contain {config_field} placeholders)
         base_url = defn.base_url.rstrip("/")
@@ -235,13 +245,13 @@ class PluginService(BaseService):
             base_url = config_values["site_url"].rstrip("/")
         else:
             try:
-                base_url = base_url.format(**config_values)
+                base_url = base_url.format(**url_values)
             except KeyError:
                 pass  # unresolved placeholders stay as-is
 
-        # Build path params from endpoint parameters + config values
-        path_params: Dict[str, Any] = {**config_values}
-        query_params: Dict[str, Any] = {}
+        # Build path params from endpoint parameters + config values (sensitive included)
+        path_params: Dict[str, Any] = dict(url_values)
+        query_params: Dict[str, Any] = dict(auth_query_params)
         body_params: Dict[str, Any] = {}
         header_params: Dict[str, str] = {}
 
@@ -327,9 +337,8 @@ class PluginService(BaseService):
                 # Token was rejected — evict the stale cache entry and retry once
                 self._jwt_cache.pop(plugin_id, None)
                 retry_headers: Dict[str, str] = {"Content-Type": "application/json"}
-                retry_headers.update(
-                    await self._resolve_auth_headers(plugin_id, defn, creds, defn.base_url)
-                )
+                retry_auth_headers, _ = await self._resolve_auth(plugin_id, defn, creds, defn.base_url)
+                retry_headers.update(retry_auth_headers)
                 if use_ado_patch_content_type:
                     retry_headers["Content-Type"] = "application/json-patch+json"
                 retry_headers.update(header_params)
@@ -357,20 +366,29 @@ class PluginService(BaseService):
     # Auth
     # ------------------------------------------------------------------
 
-    async def _resolve_auth_headers(
+    async def _resolve_auth(
         self,
         plugin_id: str,
         defn: PluginDefinition,
         creds: Dict[str, Any],
         base_url: str,
-    ) -> Dict[str, str]:
-        """Dispatch to the correct auth header builder (sync or async)."""
+    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Dispatch to the correct auth builder (sync or async).
+
+        Returns ``(headers, query_params)`` — most auth types only populate
+        headers; ``type="query"`` (for APIs that require the API key as a
+        query/path parameter rather than a header) only populates
+        query_params.
+        """
         if defn.auth.type == "api_key_with_jwt":
-            return await self._build_api_key_with_jwt_headers(plugin_id, defn.auth, creds, base_url)
-        return self._build_auth_headers(defn.auth, creds)
+            headers = await self._build_api_key_with_jwt_headers(plugin_id, defn.auth, creds, base_url)
+            return headers, {}
+        if defn.auth.type == "query":
+            return {}, self._build_auth_query_params(defn.auth, creds)
+        return self._build_auth_headers(defn.auth, creds), {}
 
     def _build_auth_headers(self, auth: PluginAuth, credentials: Dict[str, Any]) -> Dict[str, str]:
-        """Build HTTP authentication headers for the three simple auth types."""
+        """Build HTTP authentication headers for the three simple header-based auth types."""
         auth_type = auth.type
 
         if auth_type == "bearer":
@@ -395,6 +413,16 @@ class PluginService(BaseService):
             return {"Authorization": f"Basic {encoded}"}
 
         return {}
+
+    def _build_auth_query_params(
+        self, auth: PluginAuth, credentials: Dict[str, Any]
+    ) -> Dict[str, str]:
+        """Build the query-string parameter for type="query" auth (e.g. an api_key param)."""
+        token = credentials.get("token", "")
+        if not token:
+            return {}
+        param_name = auth.query_param_name or "api_key"
+        return {param_name: token}
 
     async def _build_api_key_with_jwt_headers(
         self,
@@ -568,7 +596,7 @@ class PluginService(BaseService):
         cred_data: Dict[str, str] = {}
         auth_type = defn.auth.type
 
-        if auth_type == "bearer" or auth_type == "header":
+        if auth_type in ("bearer", "header", "query"):
             if request.token:
                 cred_data["token"] = request.token
         elif auth_type == "basic":
@@ -702,9 +730,14 @@ class PluginService(BaseService):
                 pass
 
         try:
-            headers = await self._resolve_auth_headers(plugin_id, defn, creds, base_url)
+            headers, query_params = await self._resolve_auth(plugin_id, defn, creds, base_url)
             async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.head(base_url, headers=headers, follow_redirects=True)
+                response = await client.head(
+                    base_url,
+                    headers=headers,
+                    params=query_params or None,
+                    follow_redirects=True,
+                )
             # HEAD returning 4xx may still mean the server is reachable
             if response.status_code < 500:
                 return {"success": True, "message": f"Connected ({response.status_code})"}
@@ -773,6 +806,10 @@ class PluginService(BaseService):
             fields = ["token (API key / Bearer token)"]
         elif auth_type == "header":
             fields = [f"token (sent as {defn.auth.header_name or 'X-API-Key'} header)"]
+        elif auth_type == "query":
+            fields = [
+                f"token (sent as the '{defn.auth.query_param_name or 'api_key'}' query parameter)"
+            ]
         elif auth_type == "basic":
             if defn.auth.fixed_password is not None:
                 fields = ["token (used as username; password is hardcoded)"]

--- a/src/services/plugin_service.py
+++ b/src/services/plugin_service.py
@@ -235,7 +235,9 @@ class PluginService(BaseService):
 
         # Build auth headers/query params (may perform an async JWT fetch for api_key_with_jwt)
         headers: Dict[str, str] = {"Content-Type": "application/json"}
-        auth_headers, auth_query_params = await self._resolve_auth(plugin_id, defn, creds, defn.base_url)
+        auth_headers, auth_query_params = await self._resolve_auth(
+            plugin_id, defn, creds, defn.base_url
+        )
         headers.update(auth_headers)
 
         # Resolve base URL (may contain {config_field} placeholders)
@@ -337,7 +339,9 @@ class PluginService(BaseService):
                 # Token was rejected — evict the stale cache entry and retry once
                 self._jwt_cache.pop(plugin_id, None)
                 retry_headers: Dict[str, str] = {"Content-Type": "application/json"}
-                retry_auth_headers, _ = await self._resolve_auth(plugin_id, defn, creds, defn.base_url)
+                retry_auth_headers, _ = await self._resolve_auth(
+                    plugin_id, defn, creds, defn.base_url
+                )
                 retry_headers.update(retry_auth_headers)
                 if use_ado_patch_content_type:
                     retry_headers["Content-Type"] = "application/json-patch+json"
@@ -381,7 +385,9 @@ class PluginService(BaseService):
         query_params.
         """
         if defn.auth.type == "api_key_with_jwt":
-            headers = await self._build_api_key_with_jwt_headers(plugin_id, defn.auth, creds, base_url)
+            headers = await self._build_api_key_with_jwt_headers(
+                plugin_id, defn.auth, creds, base_url
+            )
             return headers, {}
         if defn.auth.type == "query":
             return {}, self._build_auth_query_params(defn.auth, creds)

--- a/src/ui/static/js/settings.js
+++ b/src/ui/static/js/settings.js
@@ -2194,12 +2194,13 @@ function createPluginCard(plugin) {
         bearer: 'Bearer Token',
         header: 'API Key Header',
         basic: 'Basic Auth',
-        api_key_with_jwt: 'API Key + JWT'
+        api_key_with_jwt: 'API Key + JWT',
+        query: 'API Key (Query Param)'
     }[plugin.auth_type] || plugin.auth_type;
 
     // Build credential fields based on auth type
     let credentialFields = '';
-    if (plugin.auth_type === 'bearer' || plugin.auth_type === 'header') {
+    if (plugin.auth_type === 'bearer' || plugin.auth_type === 'header' || plugin.auth_type === 'query') {
         credentialFields = `
             <div class="form-group">
                 <label class="form-label">API Token / Secret</label>
@@ -2267,7 +2268,8 @@ function createPluginCard(plugin) {
             </div>`;
     }
 
-    // Build non-sensitive config fields
+    // Build config fields: plain text for non-sensitive, masked password input for sensitive
+    // (e.g. a secret meant to be embedded in the URL path/base_url rather than sent as a header).
     let configFieldsHtml = '';
     for (const field of (plugin.config_fields || [])) {
         if (!field.sensitive) {
@@ -2277,6 +2279,19 @@ function createPluginCard(plugin) {
                     <input type="text" id="plugin-config-${plugin.id}-${field.key}" class="form-input"
                         placeholder="${field.placeholder || ''}"
                         data-config-key="${field.key}">
+                    ${field.description ? `<div class="form-hint">${field.description}</div>` : ''}
+                </div>`;
+        } else {
+            const inputId = `plugin-config-${plugin.id}-${field.key}`;
+            configFieldsHtml += `
+                <div class="form-group">
+                    <label class="form-label">${field.display_name}${field.required ? ' <span style="color:#ff4444">*</span>' : ''}</label>
+                    <div class="input-group">
+                        <input type="password" id="${inputId}" class="form-input masked-input"
+                            placeholder="${field.placeholder || ''}" data-config-key="${field.key}"
+                            value="${plugin.has_credentials ? '***MASKED***' : ''}">
+                        <button type="button" onclick="toggleMasked('${inputId}')" class="btn-icon">👁️</button>
+                    </div>
                     ${field.description ? `<div class="form-hint">${field.description}</div>` : ''}
                 </div>`;
         }
@@ -2382,11 +2397,11 @@ async function savePluginCredentials(pluginId) {
         body.password = passwordInput.value;
     }
 
-    // Collect non-sensitive config fields
+    // Collect config field values (plain + sensitive, skipping unchanged masked secrets)
     const card = document.getElementById(`plugin-card-${pluginId}`);
     if (card) {
         card.querySelectorAll('[data-config-key]').forEach(input => {
-            if (input.value) {
+            if (input.value && input.value !== '***MASKED***') {
                 body.config[input.dataset.configKey] = input.value;
             }
         });

--- a/tests/test_plugin_dual_auth.py
+++ b/tests/test_plugin_dual_auth.py
@@ -178,6 +178,57 @@ class TestBuildAuthHeaders:
 
 
 # ---------------------------------------------------------------------------
+# _build_auth_query_params / _resolve_auth — type="query"
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuthQueryParams:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+
+    def test_default_param_name(self):
+        auth = PluginAuth(type="query")
+        qp = self.svc._build_auth_query_params(auth, {"token": "tok123"})
+        assert qp == {"api_key": "tok123"}
+
+    def test_custom_param_name(self):
+        auth = PluginAuth(type="query", query_param_name="apiKey")
+        qp = self.svc._build_auth_query_params(auth, {"token": "tok123"})
+        assert qp == {"apiKey": "tok123"}
+
+    def test_missing_token_yields_no_param(self):
+        auth = PluginAuth(type="query")
+        qp = self.svc._build_auth_query_params(auth, {})
+        assert qp == {}
+
+    @pytest.mark.asyncio
+    async def test_resolve_auth_dispatches_to_query(self):
+        defn = PluginDefinition.model_validate(
+            {
+                "id": "query_auth_svc",
+                "display_name": "Query Auth Service",
+                "description": "Test query-param-auth plugin.",
+                "base_url": "https://api.example.com",
+                "auth": {"type": "query", "query_param_name": "api_key"},
+                "endpoints": [
+                    {
+                        "name": "get_facebook_data",
+                        "display_name": "Get Facebook Data",
+                        "description": "Get data.",
+                        "method": "GET",
+                        "path": "/facebook",
+                    }
+                ],
+            }
+        )
+        headers, query_params = await self.svc._resolve_auth(
+            "query_auth_svc", defn, {"token": "secret"}, defn.base_url
+        )
+        assert headers == {}
+        assert query_params == {"api_key": "secret"}
+
+
+# ---------------------------------------------------------------------------
 # _get_jwt — caching and fetching
 # ---------------------------------------------------------------------------
 
@@ -407,8 +458,8 @@ class TestExecuteEndpoint401Retry:
             patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client),
             patch.object(
                 self.svc,
-                "_resolve_auth_headers",
-                AsyncMock(side_effect=[headers_v1, headers_v2]),
+                "_resolve_auth",
+                AsyncMock(side_effect=[(headers_v1, {}), (headers_v2, {})]),
             ),
         ):
             result = await self.svc._execute_endpoint("my_service", "list_items", {})
@@ -441,8 +492,8 @@ class TestExecuteEndpoint401Retry:
             patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client),
             patch.object(
                 self.svc,
-                "_resolve_auth_headers",
-                AsyncMock(return_value={"Authorization": "Access_Token tok"}),
+                "_resolve_auth",
+                AsyncMock(return_value=({"Authorization": "Access_Token tok"}, {})),
             ),
         ):
             with pytest.raises(real_httpx.HTTPStatusError):
@@ -490,3 +541,126 @@ class TestExecuteEndpoint401Retry:
                 await self.svc._execute_endpoint("bearer_svc", "get_data", {})
 
         assert mock_client.request.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _execute_endpoint — end-to-end wiring for type="query" auth
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteEndpointQueryAuth:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+        self.defn = PluginDefinition.model_validate(
+            {
+                "id": "query_auth_svc",
+                "display_name": "Query Auth Service",
+                "description": "Test query-param-auth plugin.",
+                "base_url": "https://api.example.com",
+                "auth": {"type": "query", "query_param_name": "api_key"},
+                "endpoints": [
+                    {
+                        "name": "get_facebook_data",
+                        "display_name": "Get Facebook Data",
+                        "description": "Get data.",
+                        "method": "GET",
+                        "path": "/facebook",
+                        "parameters": [
+                            {
+                                "name": "fields",
+                                "in": "query",
+                                "type": "string",
+                                "description": "Fields to return.",
+                                "required": True,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        self.svc._definitions["query_auth_svc"] = self.defn
+        self.svc.credentials_repo.get.side_effect = lambda key: (
+            {"credential_data": {"token": "SECRET123"}} if key == "plugin_query_auth_svc" else None
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_key_sent_as_query_param_not_header(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b'{"data": []}'
+        resp.json.return_value = {"data": []}
+        resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.request = AsyncMock(return_value=resp)
+
+        with patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client):
+            result = await self.svc._execute_endpoint(
+                "query_auth_svc", "get_facebook_data", {"fields": "date,spend"}
+            )
+
+        assert result == {"data": []}
+        _, call_kwargs = mock_client.request.call_args
+        # The secret must travel as a query param, merged with the endpoint's own params.
+        assert call_kwargs["params"] == {"api_key": "SECRET123", "fields": "date,spend"}
+        # ...and must NOT leak into the headers.
+        assert "api_key" not in call_kwargs["headers"]
+        assert "SECRET123" not in call_kwargs["headers"].values()
+
+
+# ---------------------------------------------------------------------------
+# _execute_endpoint — sensitive config_fields substitute into path/base_url
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteEndpointSensitiveConfigInPath:
+    def setup_method(self):
+        self.svc = _make_plugin_service()
+        self.defn = PluginDefinition.model_validate(
+            {
+                "id": "path_key_svc",
+                "display_name": "Path Key Service",
+                "description": "API key embedded in the URL path.",
+                "base_url": "https://api.example.com",
+                "auth": {"type": "header", "header_name": "X-Unused"},
+                "config_fields": [
+                    {"key": "api_key", "display_name": "API Key", "sensitive": True}
+                ],
+                "endpoints": [
+                    {
+                        "name": "get_report",
+                        "display_name": "Get Report",
+                        "description": "Get report.",
+                        "method": "GET",
+                        "path": "/v1/{api_key}/report",
+                    }
+                ],
+            }
+        )
+        self.svc._definitions["path_key_svc"] = self.defn
+        self.svc.credentials_repo.get.side_effect = lambda key: (
+            {"credential_data": {"token": "unused", "api_key": "PATHSECRET"}}
+            if key == "plugin_path_key_svc"
+            else None
+        )
+
+    @pytest.mark.asyncio
+    async def test_sensitive_config_field_substituted_into_path(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"{}"
+        resp.json.return_value = {}
+        resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.request = AsyncMock(return_value=resp)
+
+        with patch("src.services.plugin_service.httpx.AsyncClient", return_value=mock_client):
+            await self.svc._execute_endpoint("path_key_svc", "get_report", {})
+
+        _, call_kwargs = mock_client.request.call_args
+        assert call_kwargs["url"] == "https://api.example.com/v1/PATHSECRET/report"

--- a/tests/test_plugin_dual_auth.py
+++ b/tests/test_plugin_dual_auth.py
@@ -625,9 +625,7 @@ class TestExecuteEndpointSensitiveConfigInPath:
                 "description": "API key embedded in the URL path.",
                 "base_url": "https://api.example.com",
                 "auth": {"type": "header", "header_name": "X-Unused"},
-                "config_fields": [
-                    {"key": "api_key", "display_name": "API Key", "sensitive": True}
-                ],
+                "config_fields": [{"key": "api_key", "display_name": "API Key", "sensitive": True}],
                 "endpoints": [
                     {
                         "name": "get_report",


### PR DESCRIPTION
## Summary
This PR adds support for a new authentication type (`type="query"`) that allows plugins to send API credentials as query-string parameters instead of HTTP headers. This is necessary for APIs that reject header-based authentication and require the API key to be embedded in the request URL.

## Key Changes

- **New auth type `"query"`**: Added `type="query"` to the `PluginAuth` model with an optional `query_param_name` field (defaults to `"api_key"`)
- **Auth resolution refactored**: Renamed `_resolve_auth_headers()` to `_resolve_auth()` to return both headers and query parameters as a tuple `(Dict[str, str], Dict[str, str])`
- **Query parameter builder**: Implemented `_build_auth_query_params()` method that extracts the token from credentials and formats it as a query parameter
- **Endpoint execution updated**: Modified `_execute_endpoint()` to merge auth query parameters with endpoint-defined query parameters before making requests
- **Sensitive config fields in URLs**: Added support for sensitive config fields (marked `"sensitive": true`) to be substituted into URL paths and `base_url`, enabling APIs that require secrets embedded directly in the URL path (e.g., `/v1/{api_key}/report`)
- **Credentials handling**: Updated `save_credentials()` to accept tokens for `type="query"` auth
- **Plugin testing**: Updated `test_plugin()` to pass query parameters when testing connectivity
- **UI support**: Added form fields in the settings UI to handle query-parameter auth and sensitive config fields with masked password inputs
- **OpenAPI import**: Enhanced OpenAPI schema importer to recognize and convert `apikey` schemes with `in: "query"` location to the new auth type
- **Documentation**: Updated plugin schema documentation with examples and explanations of the new query-parameter auth type and sensitive config fields

## Implementation Details

- Query parameters from auth are merged with endpoint parameters in a single `params` dict passed to `httpx.AsyncClient.request()`
- The auth query parameter is never leaked into response headers
- Sensitive config fields are stored encrypted in credentials (like other sensitive data) but can be referenced in URL templates using `{field_key}` placeholders
- The retry logic for JWT auth was updated to work with the new tuple return value from `_resolve_auth()`
- All existing auth types continue to work unchanged; this is purely additive functionality